### PR TITLE
Always treat -etcd-path as a directory

### DIFF
--- a/main.go
+++ b/main.go
@@ -67,10 +67,10 @@ func newNetworkManager() (controller.Controller, error) {
 func newSubnetRegistry() registry.SubnetRegistry {
 	peers := strings.Split(opts.etcdEndpoints, ",")
 
-	subnetPath := path.Join(opts.etcdPath + "subnets")
+	subnetPath := path.Join(opts.etcdPath, "subnets")
 	minionPath := "/registry/minions/"
 	if opts.sync {
-		minionPath = path.Join(opts.etcdPath + "minions")
+		minionPath = path.Join(opts.etcdPath, "minions")
 	}
 
 	cfg := &registry.EtcdConfig{


### PR DESCRIPTION
`newSubnetRegistry()`: Pass `opts.etcdPath` and the subdirectory name (either "subnets" or "minions") to `path.Join` as separate arguments rather than catenating them as strings and passing the catenated string to `path.Join`.

Before this change, if `-etcd-path` were passed a pathname "/foo" that did not end with a slash, openshift-sdn would use directory names "/foosubnets" and "/foominions" instead of "/foo/subnets" and "/foo/minions".