### PR TITLE
WatchMinions: Correctly handle errors

### DIFF
--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -262,7 +262,7 @@ func (sub *EtcdSubnetRegistry) WatchMinions(rev uint64, receiver chan *MinionEve
 	log.Infof("Watching %s for new minions.", key)
 	for {
 		resp, err := sub.watch(key, rev, stop)
-		if resp == nil && err == nil {
+		if resp == nil || err != nil {
 			continue
 		}
 		rev = resp.Node.ModifiedIndex + 1


### PR DESCRIPTION
If we get a `nil` response or a non-`nil` error, then retry the watch. Before this change, in the case of a `nil` response and a non-`nil` error, `WatchMinions` would try to dereference the `nil` response.