### PR TITLE
Remove unnecessary print

### DIFF
--- a/pkg/netutils/ip_allocator.go
+++ b/pkg/netutils/ip_allocator.go
@@ -21,6 +21,5 @@ func NewIPAllocator(network string) (*IPAllocator, error) {
 }
 
 func (ipa *IPAllocator) GetIP() (net.IP, error) {
-	fmt.Println(ipa.network.IP)
 	return ipa.network.IP, nil
 }

--- a/pkg/netutils/subnet_allocator.go
+++ b/pkg/netutils/subnet_allocator.go
@@ -18,7 +18,6 @@ func NewSubnetAllocator(network string, capacity uint, inUse []string) (*SubnetA
 	}
 
 	netMaskSize, _ := netIP.Mask.Size()
-	fmt.Println(netMaskSize)
 	if capacity > (32 - uint(netMaskSize)) {
 		return nil, fmt.Errorf("Subnet capacity cannot be larger than number of networks available")
 	}


### PR DESCRIPTION
I believe these fmt.Println are not necessary. If they are necessary, they should use log.Info or other formal message.