### PR TITLE
Add Restart=on-failure to unit files

### DIFF
--- a/rel-eng/openshift-sdn-master.service
+++ b/rel-eng/openshift-sdn-master.service
@@ -8,6 +8,8 @@ Requires=openshift-master.service
 Type=simple
 EnvironmentFile=-/etc/sysconfig/openshift-sdn-master
 ExecStart=/usr/bin/openshift-sdn $OPTIONS
+Restart=on-failure
+RestartSec=1s
 
 [Install]
 WantedBy=multi-user.target

--- a/rel-eng/openshift-sdn-node.service
+++ b/rel-eng/openshift-sdn-node.service
@@ -9,6 +9,8 @@ Documentation=https://github.com/openshift/origin
 Type=simple
 EnvironmentFile=-/etc/sysconfig/openshift-sdn-node
 ExecStart=/usr/bin/openshift-sdn -minion -etcd-endpoints=${MASTER_URL} -public-ip=${MINION_IP} $OPTIONS
+Restart=on-failure
+RestartSec=1s
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Add `Restart=on-failure` to the unit files for openshift-sdn-master and openshift-sdn-node.