### PR TITLE
Improve output formatting

### DIFF
--- a/ovs-simple/bin/openshift-sdn-simple-setup-node.sh
+++ b/ovs-simple/bin/openshift-sdn-simple-setup-node.sh
@@ -2,7 +2,7 @@
 
 set -ex
 
-echo $@
+printf 'Container network is "%s"; local host has subnet "%s" and gateway "%s".\n' "$3" "$2" "$1"
 
 ## openvswitch
 ovs-vsctl del-br br0 || true

--- a/pkg/netutils/subnet_allocator.go
+++ b/pkg/netutils/subnet_allocator.go
@@ -19,7 +19,7 @@ func NewSubnetAllocator(network string, capacity uint, inUse []string) (*SubnetA
 
 	netMaskSize, _ := netIP.Mask.Size()
 	if capacity > (32 - uint(netMaskSize)) {
-		return nil, fmt.Errorf("Subnet capacity cannot be larger than number of networks available")
+		return nil, fmt.Errorf("Subnet capacity cannot be larger than number of networks available.")
 	}
 
 	amap := make(map[string]bool)
@@ -65,12 +65,12 @@ func (sna *SubnetAllocator) GetNetwork() (*net.IPNet, error) {
 
 func (sna *SubnetAllocator) ReleaseNetwork(ipnet *net.IPNet) error {
 	if !sna.network.Contains(ipnet.IP) {
-		return fmt.Errorf("Provided subnet %v doesn't belong to the network %v", ipnet, sna.network)
+		return fmt.Errorf("Provided subnet %v doesn't belong to the network %v.", ipnet, sna.network)
 	}
 
 	ipnetStr := ipnet.String()
 	if !sna.allocMap[ipnetStr] {
-		return fmt.Errorf("Provided subnet %v is already available", ipnet)
+		return fmt.Errorf("Provided subnet %v is already available.", ipnet)
 	}
 
 	sna.allocMap[ipnetStr] = false


### PR DESCRIPTION
Use clearer and more consistent formatting for output.

Consistently format error values using `%v` with the error values themselves rather than using `%s` and `err.Error()`.

Indicate that we are printing the container network, local host subnet, and gateway for the latter during initialization of openshift-sdn in node mode rather than cryptically printing IP addresses and CIDR suffixes with no explanation of what they are.

Indicate that we are printing the subnet prefix length during initialization of openshift-sdn in master mode rather than cryptically printing a lone number with no explanation of what it means.