### PR TITLE
Make service dependency ordering more strict

### DIFF
--- a/rel-eng/openshift-sdn-master.service
+++ b/rel-eng/openshift-sdn-master.service
@@ -2,7 +2,9 @@
 Description=OpenShift SDN Master
 Documentation=https://github.com/openshift/openshift-sdn
 After=openshift-master.service
-Requires=openshift-master.service
+Wants=openshift-master.service
+Before=openshift-sdn-node.service
+Before=openshift-node.service
 
 [Service]
 Type=simple

--- a/rel-eng/openshift-sdn-node.service
+++ b/rel-eng/openshift-sdn-node.service
@@ -1,8 +1,13 @@
 [Unit]
 Description=OpenShift SDN Node
-Before=openshift-node.service
 After=openvswitch.service
+After=openshift-sdn-master.service
+After=openshift-master.service
+Wants=openshit-sdn-master.service
+Wants=openshift-master.service
 Requires=openvswitch.service
+Before=openshift-node.service
+Before=docker.service
 Documentation=https://github.com/openshift/origin
 
 [Service]


### PR DESCRIPTION
This formalizes service startup ordering.
Before/After only affect ordering.
Wants/Requires affects dependencies, wants being a weaker form of Requires that will trigger the dependency to start but will carry on if the dependency fails.

My only concern is that I wonder if we should add Before=docker.service because if we don't and we've run openshift-sdn previously it will have configured docker to use lbr0 which will not exist after a reboot before openshift-sdn has created it.