### PR TITLE
netutils server

### DIFF
--- a/hack/test.sh
+++ b/hack/test.sh
@@ -1,2 +1,3 @@
 #!/bin/bash
 go test -v github.com/openshift/openshift-sdn/pkg/netutils
+go test -v github.com/openshift/openshift-sdn/pkg/netutils/server

--- a/pkg/netutils/server/server.go
+++ b/pkg/netutils/server/server.go
@@ -1,0 +1,119 @@
+package server
+
+import (
+	"crypto/tls"
+	"fmt"
+	"net"
+	"net/http"
+	"strconv"
+	"time"
+)
+
+// Server is a http.Handler which exposes netutils functionality over HTTP.
+type Server struct {
+	ipam IpamInterface
+	mux  *http.ServeMux
+}
+
+type TLSOptions struct {
+	Config   *tls.Config
+	CertFile string
+	KeyFile  string
+}
+
+// ListenAndServeNetutilServer initializes a server to respond to HTTP network requests on the ipam interface
+func ListenAndServeNetutilServer(ipam IpamInterface, address net.IP, port uint, tlsOptions *TLSOptions) {
+	handler := NewServer(ipam)
+	s := &http.Server{
+		Addr:           net.JoinHostPort(address.String(), strconv.FormatUint(uint64(port), 10)),
+		Handler:        handler,
+		ReadTimeout:    5 * time.Minute,
+		WriteTimeout:   5 * time.Minute,
+		MaxHeaderBytes: 1 << 20,
+	}
+	if tlsOptions != nil {
+		s.TLSConfig = tlsOptions.Config
+		s.ListenAndServeTLS(tlsOptions.CertFile, tlsOptions.KeyFile)
+	} else {
+		s.ListenAndServe()
+	}
+}
+
+// IpamInterface contains all the methods required by the server.
+type IpamInterface interface {
+	GetIP() (*net.IPNet, error)
+	ReleaseIP(ip *net.IPNet) error
+	//GetStats() string
+}
+
+// NewServer initializes and configures the netutils_server.Server object to handle HTTP requests.
+func NewServer(ipam IpamInterface) *Server {
+	server := Server{
+		ipam: ipam,
+		mux:  http.NewServeMux(),
+	}
+	server.InstallDefaultHandlers()
+	return &server
+}
+
+// InstallDefaultHandlers registers the default set of supported HTTP request patterns with the mux.
+func (s *Server) InstallDefaultHandlers() {
+	s.mux.HandleFunc("/netutils/subnet", s.handleSubnet)
+	s.mux.HandleFunc("/netutils/ip/", s.handleIP)
+	s.mux.HandleFunc("/netutils/gateway", s.handleGateway)
+	s.mux.HandleFunc("/stats", s.handleStats)
+}
+
+// error serializes an error object into an HTTP response.
+func (s *Server) error(w http.ResponseWriter, err error) {
+	msg := fmt.Sprintf("Internal Error: %v", err)
+	http.Error(w, msg, http.StatusInternalServerError)
+}
+
+// handleSubnet handles gateway requests
+func (s *Server) handleSubnet(w http.ResponseWriter, req *http.Request) {
+	w.Header().Add("Content-type", "application/json")
+	w.Write([]byte("Not implemented"))
+	return
+}
+
+// handleGateway handles gateway requests
+func (s *Server) handleGateway(w http.ResponseWriter, req *http.Request) {
+	w.Header().Add("Content-type", "application/json")
+	w.Write([]byte("Not implemented"))
+	return
+}
+
+// handleIP handles IP requests
+func (s *Server) handleIP(w http.ResponseWriter, req *http.Request) {
+	if req.Method == "GET" {
+		w.Header().Add("Content-type", "application/json")
+		ipnet, _ := s.ipam.GetIP()
+		w.Write([]byte(ipnet.String()))
+	} else if req.Method == "DELETE" {
+		ip, ipNet, err := net.ParseCIDR(req.URL.Path[len("/netutils/ip/"):])
+		if err != nil {
+			s.error(w, err)
+		}
+		delIP := &net.IPNet{IP: ip, Mask: ipNet.Mask}
+		err = s.ipam.ReleaseIP(delIP)
+		if err != nil {
+			s.error(w, err)
+		}
+	} else {
+		http.Error(w, "Method can only be GET/DELETE", http.StatusNotFound)
+	}
+	return
+}
+
+// handleStats handles stats requests
+func (s *Server) handleStats(w http.ResponseWriter, req *http.Request) {
+	w.Header().Add("Content-type", "application/json")
+	w.Write([]byte("Not implemented"))
+	return
+}
+
+// ServeHTTP responds to HTTP requests
+func (s *Server) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	s.mux.ServeHTTP(w, req)
+}

--- a/pkg/netutils/server/server_test.go
+++ b/pkg/netutils/server/server_test.go
@@ -1,0 +1,70 @@
+package server
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net"
+	"net/http"
+	"testing"
+
+	"github.com/openshift/openshift-sdn/pkg/netutils"
+)
+
+func delIP(t *testing.T, delip string) error {
+	url := fmt.Sprintf("http://127.0.0.1:9080/netutils/ip/%s", delip)
+	req, err := http.NewRequest("DELETE", url, nil)
+	if err != nil {
+		t.Fatal("Error in forming request to IPAM server")
+	}
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal("Error in connecting to IPAM server")
+	}
+	if res.StatusCode > 400 {
+		return fmt.Errorf("Bad response from server: %d", res.StatusCode)
+	}
+	return err
+}
+
+func getIP(t *testing.T) string {
+	res, err := http.Get("http://127.0.0.1:9080/netutils/ip")
+	if err != nil {
+		t.Fatal("Error in connecting to IPAM server")
+	}
+	ip, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		t.Fatal("Error in obtaining IP address through server")
+	}
+	res.Body.Close()
+	return string(ip)
+}
+
+func TestIPServe(t *testing.T) {
+	inuse := make([]string, 0)
+	ipam, _ := netutils.NewIPAllocator("10.20.30.40/24", inuse)
+	go ListenAndServeNetutilServer(ipam, net.ParseIP("127.0.0.1"), 9080, nil)
+
+	// get, get, delete, get
+	ip := getIP(t)
+	if ip != "10.20.30.1/24" {
+		t.Fatalf("Wrong IP. Expected 10.20.30.1/24, got %s", ip)
+	}
+	ip = getIP(t)
+	if ip != "10.20.30.2/24" {
+		t.Fatalf("Wrong IP. Expected 10.20.30.2/24, got %s", ip)
+	}
+	err := delIP(t, ip)
+	if err != nil {
+		t.Fatalf("Error while deleting IP address %s: %v", ip, err)
+	}
+	// get it again
+	ip = getIP(t)
+	if ip != "10.20.30.2/24" {
+		t.Fatalf("Wrong IP. Expected 10.20.30.2/24, got %s", ip)
+	}
+	// delete the wrong one and fail if there is no error
+	err = delIP(t, "10.10.10.10/23")
+	if err == nil {
+		t.Fatalf("Error while deleting IP address %s: %v", ip, err)
+	}
+}

--- a/pkg/netutils/server/server_test.go
+++ b/pkg/netutils/server/server_test.go
@@ -41,7 +41,10 @@ func getIP(t *testing.T) string {
 
 func TestIPServe(t *testing.T) {
 	inuse := make([]string, 0)
-	ipam, _ := netutils.NewIPAllocator("10.20.30.40/24", inuse)
+	ipam, err := netutils.NewIPAllocator("10.20.30.40/24", inuse)
+	if err != nil {
+		t.Fatalf("Error while initializing IPAM: %v", err)
+	}
 	go ListenAndServeNetutilServer(ipam, net.ParseIP("127.0.0.1"), 9080, nil)
 
 	// get, get, delete, get
@@ -53,7 +56,7 @@ func TestIPServe(t *testing.T) {
 	if ip != "10.20.30.2/24" {
 		t.Fatalf("Wrong IP. Expected 10.20.30.2/24, got %s", ip)
 	}
-	err := delIP(t, ip)
+	err = delIP(t, ip)
 	if err != nil {
 		t.Fatalf("Error while deleting IP address %s: %v", ip, err)
 	}


### PR DESCRIPTION
An http REST based IPAM server - basic implementation that serves IPs for now, but meant to serve subnets too.
The test uses the netutils package as an example.

@mrunalp PTAL