### PR TITLE
Add SyslogIdentifier=openshift-sdn-{master,node} respectively

### DIFF
--- a/rel-eng/openshift-sdn-master.service
+++ b/rel-eng/openshift-sdn-master.service
@@ -11,6 +11,7 @@ EnvironmentFile=-/etc/sysconfig/openshift-sdn-master
 ExecStart=/usr/bin/openshift-sdn $OPTIONS
 Restart=on-failure
 RestartSec=1s
+SyslogIdentifier=openshift-sdn-master
 
 [Install]
 WantedBy=multi-user.target

--- a/rel-eng/openshift-sdn-node.service
+++ b/rel-eng/openshift-sdn-node.service
@@ -14,6 +14,7 @@ EnvironmentFile=-/etc/sysconfig/openshift-sdn-node
 ExecStart=/usr/bin/openshift-sdn -minion -etcd-endpoints=${MASTER_URL} -public-ip=${MINION_IP} $OPTIONS
 Restart=on-failure
 RestartSec=1s
+SyslogIdentifier=openshift-sdn-node
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
This will allow rsyslog users to split master and node logs if they
wish to do so.