### PR TITLE
StartNode: return if GetSubnets returns error

### DIFF
--- a/ovs-simple/controller/controller.go
+++ b/ovs-simple/controller/controller.go
@@ -200,6 +200,7 @@ func (oc *OvsController) StartNode(sync, skipsetup bool) error {
 		subnets, err := oc.subnetRegistry.GetSubnets()
 		if err != nil {
 			log.Errorf("Could not fetch existing subnets: %v", err)
+			return err
 		}
 		for _, s := range *subnets {
 			oc.AddOFRules(s.Minion, s.Sub)


### PR DESCRIPTION
Change `controller.(*OvsController).StartNode` so that if it gets an error from `GetSubnets`, `StartNode` will return that error rather than continuing on to dereference a nil pointer and panic.