### PR TITLE
first set of reorg for api-fication of openshift-sdn

### DIFF
--- a/main.go
+++ b/main.go
@@ -12,6 +12,7 @@ import (
 
 	log "github.com/golang/glog"
 	"github.com/openshift/openshift-sdn/ovssubnet"
+	"github.com/openshift/openshift-sdn/pkg/api"
 	"github.com/openshift/openshift-sdn/pkg/registry"
 )
 
@@ -83,7 +84,7 @@ func newNetworkManager() (NetworkManager, error) {
 	return ovssubnet.NewDefaultController(sub, string(host), opts.ip)
 }
 
-func newSubnetRegistry() (registry.SubnetRegistry, error) {
+func newSubnetRegistry() (api.SubnetRegistry, error) {
 	peers := strings.Split(opts.etcdEndpoints, ",")
 
 	subnetPath := path.Join(opts.etcdPath, "subnets")

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -1,0 +1,43 @@
+package api
+
+type EventType string
+
+const (
+	Added   EventType = "ADDED"
+	Deleted EventType = "DELETED"
+)
+
+type SubnetRegistry interface {
+	InitSubnets() error
+	GetSubnets() (*[]Subnet, error)
+	GetSubnet(minion string) (*Subnet, error)
+	DeleteSubnet(minion string) error
+	CreateSubnet(sn string, sub *Subnet) error
+	WatchSubnets(rev uint64, receiver chan *SubnetEvent, stop chan bool) error
+
+	InitMinions() error
+	GetMinions() (*[]string, error)
+	CreateMinion(minion string, data string) error
+	WatchMinions(rev uint64, receiver chan *MinionEvent, stop chan bool) error
+
+	WriteNetworkConfig(network string, subnetLength uint) error
+	GetContainerNetwork() (string, error)
+	GetSubnetLength() (uint64, error)
+	CheckEtcdIsAlive(seconds uint64) bool
+}
+
+type SubnetEvent struct {
+	Type   EventType
+	Minion string
+	Sub    Subnet
+}
+
+type MinionEvent struct {
+	Type   EventType
+	Minion string
+}
+
+type Subnet struct {
+	Minion string
+	Sub    string
+}


### PR DESCRIPTION
Moved some types/structs from registry/ package to a new api/ package. This will facilitate making registry/ as one of the interface implementations. A pluggable implementation can then, choose a non-etcd based backend as an example.

@mrunalp Review please.