### PR TITLE
Change minions path to /kubernetes.io/minions/

### DIFF
--- a/main.go
+++ b/main.go
@@ -89,7 +89,7 @@ func newSubnetRegistry() (api.SubnetRegistry, error) {
 
 	subnetPath := path.Join(opts.etcdPath, "subnets")
 	subnetConfigPath := path.Join(opts.etcdPath, "config")
-	minionPath := "/registry/minions/"
+	minionPath := "/kubernetes.io/minions/"
 	if opts.sync {
 		minionPath = path.Join(opts.etcdPath, "minions")
 	}


### PR DESCRIPTION
Storage paths were changed and also made to be configurable, /kubernetes.io/minions/ is the new default. This should probably be made configurable but given the other changes coming soon I've just done this for now.