### PR TITLE
Add ipvlan IPv4 support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,12 @@ install:
 	mkdir -p /usr/libexec/kubernetes/kubelet-plugins/net/exec/redhat~openshift-ovs-subnet/
 	cp -f $(OUT_DIR)/local/go/bin/openshift-ovs-subnet /usr/libexec/kubernetes/kubelet-plugins/net/exec/redhat~openshift-ovs-subnet/
 
+	cp -f $(OUT_DIR)/local/go/bin/openshift-ipvlan-subnet /usr/bin/
+	cp -f $(OUT_DIR)/local/go/bin/openshift-ipvlan-kube-subnet-setup.sh /usr/bin/
+	mkdir -p /usr/libexec/kubernetes/kubelet-plugins/net/exec/redhat~openshift-ipvlan-subnet/
+	cp -f $(OUT_DIR)/local/go/bin/openshift-ipvlan-subnet /usr/libexec/kubernetes/kubelet-plugins/net/exec/redhat~openshift-ipvlan-subnet/
+	cp -f $(OUT_DIR)/local/go/bin/openshift-ipvlan-dhclient-script /usr/bin/
+
 # Remove all build artifacts.
 #
 # Example:

--- a/hack/build.sh
+++ b/hack/build.sh
@@ -37,3 +37,7 @@ go install ${OSDN_GO_PACKAGE}
 cp -f ovssubnet/bin/openshift-sdn-simple-setup-node.sh ${OSDN_GOPATH}/bin
 cp -f ovssubnet/bin/openshift-ovs-subnet ${OSDN_GOPATH}/bin
 cp -f ovssubnet/bin/openshift-sdn-kube-subnet-setup.sh ${OSDN_GOPATH}/bin
+cp -f ipvlan/bin/openshift-ipvlan-subnet ${OSDN_GOPATH}/bin
+cp -f ipvlan/bin/openshift-ipvlan-kube-subnet-setup.sh ${OSDN_GOPATH}/bin
+cp -f ipvlan/bin/openshift-ipvlan-dhclient-script ${OSDN_GOPATH}/bin
+

--- a/hack/test.sh
+++ b/hack/test.sh
@@ -1,3 +1,37 @@
 #!/bin/bash
+
+set -e
+
+OSDN_ROOT=$(
+  unset CDPATH
+  osdn_root=$(dirname "${BASH_SOURCE}")/..
+  cd "${osdn_root}"
+  pwd
+)
+
+OS_OUTPUT="${OSDN_ROOT}/_output/local"
+readonly OSDN_GO_PACKAGE=github.com/openshift/openshift-sdn
+readonly OSDN_GOPATH="${OSDN_ROOT}/_output/local/go"
+
+setup_env() {
+  if [[ -z "$(which go)" ]]; then
+    echo "Can't find 'go' in PATH, please fix and retry."
+    exit 2
+  fi
+
+  local go_pkg_dir="${OSDN_GOPATH}/src/${OSDN_GO_PACKAGE}"
+  local go_pkg_basedir=$(dirname "${go_pkg_dir}")
+  mkdir -p "${go_pkg_basedir}"
+  mkdir -p "${OSDN_GOPATH}/bin"
+  rm -f "${go_pkg_dir}"
+
+  # TODO: This symlink should be relative.
+  ln -s "${OSDN_ROOT}" "${go_pkg_dir}"
+
+  GOPATH=${OSDN_GOPATH}:${OSDN_ROOT}/Godeps/_workspace
+  export GOPATH
+}
+
+setup_env
 go test -v github.com/openshift/openshift-sdn/pkg/netutils
 go test -v github.com/openshift/openshift-sdn/pkg/netutils/server

--- a/ipvlan/bin/openshift-ipvlan-dhclient-script
+++ b/ipvlan/bin/openshift-ipvlan-dhclient-script
@@ -1,0 +1,462 @@
+#!/bin/bash
+#
+# dhclient-script: Network interface configuration script run by
+#                  dhclient based on DHCP client communication
+#
+# Copyright (C) 2008-2014  Red Hat, Inc.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# Author(s): David Cantrell <dcantrell@redhat.com>
+#            Jiri Popelka <jpopelka@redhat.com>
+#
+# ----------
+# This script is a rewrite/reworking on dhclient-script originally
+# included as part of dhcp-970306:
+# dhclient-script for Linux. Dan Halbert, March, 1997.
+# Updated for Linux 2.[12] by Brian J. Murrell, January 1999.
+# Modified by David Cantrell <dcantrell@redhat.com> for Fedora and RHEL
+# ----------
+#
+
+PATH=/bin:/usr/bin:/sbin
+
+LOGFACILITY="local7"
+LOGLEVEL="notice"
+
+logmessage() {
+    msg="${1}"
+    logger -p ${LOGFACILITY}.${LOGLEVEL} -t "NET" "dhclient: ${msg}"
+}
+
+quad2num() {
+    if [ $# -eq 4 ]; then
+        let n="${1} << 24 | ${2} << 16 | ${3} << 8 | ${4}"
+        echo "${n}"
+        return 0
+    else
+        echo "0"
+        return 1
+    fi
+}
+
+ip2num() {
+    IFS="." quad2num ${1}
+}
+
+num2ip() {
+    let n="${1}"
+    let o1="(n >> 24) & 0xff"
+    let o2="(n >> 16) & 0xff"
+    let o3="(n >> 8) & 0xff"
+    let o4="n & 0xff"
+    echo "${o1}.${o2}.${o3}.${o4}"
+}
+
+get_network_address() {
+# get network address for the given IP address and (netmask or prefix)
+    ip="${1}"
+    nm="${2}"
+
+    if [ -n "${ip}" -a -n "${nm}" ]; then
+        IFS=. read -r i1 i2 i3 i4 <<< "${ip}"
+        IFS=. read -r m1 m2 m3 m4 <<< "${nm}"
+        printf "%d.%d.%d.%d" "$((i1 & m1))" "$((i2 & m2))" "$((i3 & m3))" "$((i4 & m4))"
+    fi
+}
+
+get_prefix() {
+# get prefix for the given netmask
+# http://www.linuxquestions.org/questions/programming-9/bash-cidr-calculator-646701/#post4949739
+    local nbits dec
+    local -a octets=( [255]=8 [254]=7 [252]=6 [248]=5 [240]=4
+                      [224]=3 [192]=2 [128]=1 [0]=0           )
+    
+    while read -rd '.' dec; do
+        [[ -z ${octets[dec]} ]] && echo "Error: $dec is not recognised" && exit 1
+        (( nbits += octets[dec] ))
+        (( dec < 255 )) && break
+    done <<<"${1}."
+
+    echo "$nbits"
+}
+
+class_bits() {
+    let ip=$(IFS='.' ip2num $1)
+    let bits=32
+    let mask='255'
+    for ((i=0; i <= 3; i++, 'mask<<=8')); do
+        let v='ip&mask'
+        if [ "$v" -eq 0 ] ; then
+             let bits-=8
+        else
+             break
+        fi
+    done
+    echo $bits
+}
+
+is_router_reachable() {
+    # handle DHCP servers that give us a router not on our subnet
+    router="${1}"
+    routersubnet="$(get_network_address ${router} ${new_subnet_mask})"
+    mysubnet="$(get_network_address ${new_ip_address} ${new_subnet_mask})"
+
+    if [ ! "${routersubnet}" = "${mysubnet}" ]; then
+        # TODO: This function should not have side effects such as adding or
+        # removing routes. Can this be done with "ip route get" or similar
+        # instead? Are there cases that rely on this route being created here?
+        ip -4 route replace ${router}/32 dev ${interface}
+        if [ "$?" -ne 0 ]; then
+            logmessage "failed to create host route for ${router}"
+            return 1
+        fi
+    fi
+
+    return 0
+}
+
+add_default_gateway() {
+    router="${1}"
+
+    if is_router_reachable ${router} ; then
+        metric=""
+        if [ $# -gt 1 ] && [ ${2} -gt 0 ]; then
+            metric="metric ${2}"
+        fi
+        ip -4 route replace default via ${router} dev ${interface} ${metric}
+        if [ $? -ne 0 ]; then
+            logmessage "failed to create default route: ${router} dev ${interface} ${metric}"
+            return 1
+        else
+            return 0
+        fi
+    fi
+
+    return 1
+}
+
+flush_dev() {
+# Instead of bringing the interface down (#574568)
+# explicitly clear ARP cache and flush all addresses & routes.
+    ip -4 addr flush dev ${1} >/dev/null 2>&1
+    ip -4 route flush dev ${1} >/dev/null 2>&1
+    ip -4 neigh flush dev ${1} >/dev/null 2>&1
+}
+
+remove_old_addr() {
+    if [ -n "${old_ip_address}" ]; then
+        if [ -n "${old_prefix}" ]; then
+            ip -4 addr del ${old_ip_address}/${old_prefix} dev ${interface} >/dev/null 2>&1
+        else
+            ip -4 addr del ${old_ip_address} dev ${interface} >/dev/null 2>&1
+        fi
+    fi
+}
+
+dhconfig() {
+    if [ -n "${old_ip_address}" ] && [ -n "${alias_ip_address}" ] &&
+       [ ! "${alias_ip_address}" = "${old_ip_address}" ]; then
+        # possible new alias, remove old alias first
+        ip -4 addr del ${old_ip_address} dev ${interface} label ${interface}:0
+    fi
+
+    if [ -n "${old_ip_address}" ] &&
+       [ ! "${old_ip_address}" = "${new_ip_address}" ]; then
+        # IP address changed. Delete all routes, and clear the ARP cache.
+        ip -4 addr del ${old_ip_address} dev ${interface}
+        ip -4 neigh flush dev ${1} >/dev/null 2>&1
+    fi
+
+    echo REASON ${reason} new_ip ${new_ip_address}
+
+    if [ "${reason}" = "BOUND" ] || [ "${reason}" = "REBOOT" ] ||
+       [ ! "${old_ip_address}" = "${new_ip_address}" ] ||
+       [ ! "${old_subnet_mask}" = "${new_subnet_mask}" ] ||
+       [ ! "${old_network_number}" = "${new_network_number}" ] ||
+       [ ! "${old_broadcast_address}" = "${new_broadcast_address}" ] ||
+       [ ! "${old_routers}" = "${new_routers}" ] ||
+       [ ! "${old_interface_mtu}" = "${new_interface_mtu}" ]; then
+        ip -4 addr add ${new_ip_address}/${new_prefix} broadcast ${new_broadcast_address} dev ${interface} \
+           valid_lft ${new_dhcp_lease_time} preferred_lft ${new_dhcp_lease_time} >/dev/null 2>&1
+        ip link set dev ${interface} up
+
+        # The 576 MTU is only used for X.25 and dialup connections
+        # where the admin wants low latency.  Such a low MTU can cause
+        # problems with UDP traffic, among other things.  As such,
+        # disallow MTUs from 576 and below by default, so that broken
+        # MTUs are ignored, but higher stuff is allowed (1492, 1500, etc).
+        if [ -n "${new_interface_mtu}" ] && [ ${new_interface_mtu} -gt 576 ]; then
+            ip link set dev ${interface} mtu ${new_interface_mtu}
+        fi
+
+        # gateways
+        metric="${METRIC:-}"
+        let i="${METRIC:-0}"
+        default_routers=()
+
+        for router in ${new_routers} ; do
+            added_router=-
+
+            for r in ${default_routers[@]} ; do
+                if [ "${r}" = "${router}" ]; then
+                    added_router=1
+                fi
+            done
+
+            if [ -z "${router}" ] ||
+               [ "${added_router}" = "1" ] ||
+               [ $(IFS=. ip2num ${router}) -le 0 ] ||
+               [[ ( "${router}" = "${new_broadcast_address}" ) &&
+                  ( "${new_subnet_mask}" != "255.255.255.255" ) ]]; then
+                continue
+            fi
+
+            default_routers=(${default_routers[@]} ${router})
+            add_default_gateway ${router} ${metric}
+            let i=i+1
+            metric=${i}
+        done
+
+    else # RENEW||REBIND - only update address lifetimes
+        ip -4 addr change ${new_ip_address}/${new_prefix} broadcast ${new_broadcast_address} dev ${interface} \
+           valid_lft ${new_dhcp_lease_time} preferred_lft ${new_dhcp_lease_time} >/dev/null 2>&1
+    fi
+
+    if [ ! "${new_ip_address}" = "${alias_ip_address}" ] &&
+       [ -n "${alias_ip_address}" ]; then
+        # Reset the alias address (fix: this should really only do this on changes)
+        ip -4 addr flush dev ${interface} label ${interface}:0 >/dev/null 2>&1
+        ip -4 addr add ${alias_ip_address}/${alias_prefix} broadcast ${alias_broadcast_address} dev ${interface} label ${interface}:0
+        ip -4 route replace ${alias_ip_address}/32 dev ${interface}
+    fi
+}
+
+# Section 18.1.8. (Receipt of Reply Messages) of RFC 3315 says:
+# The client SHOULD perform duplicate address detection on each of
+# the addresses in any IAs it receives in the Reply message before
+# using that address for traffic.
+add_ipv6_addr_with_DAD() {
+            ip -6 addr add ${new_ip6_address}/${new_ip6_prefixlen} \
+                dev ${interface} scope global valid_lft ${new_max_life} \
+                                          preferred_lft ${new_preferred_life}
+
+            # repeatedly test whether newly added address passed
+            # duplicate address detection (DAD)
+            for i in $(seq 5); do
+                sleep 1 # give the DAD some time
+
+                addr=$(ip -6 addr show dev ${interface} \
+                       | grep ${new_ip6_address}/${new_ip6_prefixlen})
+
+                # tentative flag == DAD is still not complete
+                tentative=$(echo "${addr}" | grep tentative)
+                # dadfailed flag == address is already in use somewhere else
+                dadfailed=$(echo "${addr}" | grep dadfailed)
+
+                if [ -n "${dadfailed}" ] ; then
+                    # address was added with valid_lft/preferred_lft 'forever', remove it
+                    ip -6 addr del ${new_ip6_address}/${new_ip6_prefixlen} dev ${interface}
+                    exit 3
+                fi
+                if [ -z "${tentative}" ] ; then
+                    if [ -n "${addr}" ]; then
+                        # DAD is over
+                        return 0
+                    else
+                        # address was auto-removed (or not added at all)
+                        exit 3
+                    fi
+                fi
+            done
+            return 0
+}
+
+dh6config() {
+    if [ -n "${old_ip6_prefix}" ] ||
+       [ -n "${new_ip6_prefix}" ]; then
+        echo Prefix ${reason} old=${old_ip6_prefix} new=${new_ip6_prefix}
+        exit 0
+    fi
+
+    case "${reason}" in
+        BOUND6)
+            if [ -z "${new_ip6_address}" ] ||
+               [ -z "${new_ip6_prefixlen}" ]; then
+                exit 2
+            fi
+
+            add_ipv6_addr_with_DAD
+            ;;
+
+        RENEW6|REBIND6)
+            if [[ -n "${new_ip6_address}" ]] &&
+               [[ -n "${new_ip6_prefixlen}" ]]; then
+               if [[  ! "${new_ip6_address}" = "${old_ip6_address}" ]]; then
+                   [[ -n "${old_ip6_address}" ]] && ip -6 addr del ${old_ip6_address} dev ${interface}
+                   add_ipv6_addr_with_DAD
+               else # only update address lifetimes
+                   ip -6 addr change ${new_ip6_address}/${new_ip6_prefixlen} \
+                      dev ${interface} scope global valid_lft ${new_max_life} \
+                                                preferred_lft ${new_preferred_life}
+               fi
+            fi
+            ;;
+
+        DEPREF6)
+            if [ -z "${new_ip6_prefixlen}" ]; then
+                exit 2
+            fi
+
+            ip -6 addr change ${new_ip6_address}/${new_ip6_prefixlen} \
+                dev ${interface} scope global preferred_lft 0
+            ;;
+    esac
+}
+
+
+#
+# ### MAIN
+#
+
+new_prefix="$(get_prefix ${new_subnet_mask})"
+old_prefix="$(get_prefix ${old_subnet_mask})"
+alias_prefix="$(get_prefix ${alias_subnet_mask})"
+
+case "${reason}" in
+    MEDIUM|ARPCHECK|ARPSEND)
+        # Do nothing
+        exit 0
+        ;;
+
+    PREINIT)
+        if [ -n "${alias_ip_address}" ]; then
+            # Flush alias, its routes will disappear too.
+            ip -4 addr flush dev ${interface} label ${interface}:0 >/dev/null 2>&1
+        fi
+
+        # upstream dhclient-script removes (ifconfig $interface 0 up) old adresses in PREINIT,
+        # but we sometimes (#125298) need (for iSCSI/nfs root to have a dhcp interface) to keep the existing ip
+        # flush_dev ${interface}
+        ip link set dev ${interface} up
+
+        exit 0
+        ;;
+
+    PREINIT6)
+        # ensure interface is up
+        ip link set dev ${interface} up
+
+        # remove any stale addresses from aborted clients
+        ip -6 addr flush dev ${interface} scope global permanent
+
+        # we need a link-local address to be ready (not tentative)
+        for i in $(seq 50); do
+            linklocal=$(ip -6 addr show dev ${interface} scope link)
+            # tentative flag means DAD is still not complete
+            tentative=$(echo "${linklocal}" | grep tentative)
+            [[ -n "${linklocal}" && -z "${tentative}" ]] && exit 0
+            sleep 0.1
+        done
+
+        exit 0
+        ;;
+
+    BOUND|RENEW|REBIND|REBOOT)
+        if [ -z "${interface}" ] || [ -z "${new_ip_address}" ]; then
+            exit 2
+        fi
+        if arping -D -q -c2 -I ${interface} ${new_ip_address}; then
+            dhconfig
+            exit 0
+        else  # DAD failed, i.e. address is already in use
+            ARP_REPLY=$(arping -D -c2 -I ${interface} ${new_ip_address} | grep reply | awk '{print toupper($5)}' | cut -d "[" -f2 | cut -d "]" -f1)
+            OUR_MACS=$(ip link show | grep link | awk '{print toupper($2)}' | uniq)
+            if [[ "${OUR_MACS}" = *"${ARP_REPLY}"* ]]; then
+                # the reply can come from our system, that's OK (#1116004#c33)
+                dhconfig
+                exit 0
+            else
+                exit 1
+            fi
+        fi
+        ;;
+
+    BOUND6|RENEW6|REBIND6|DEPREF6)
+        dh6config
+        exit 0
+        ;;
+
+    EXPIRE6|RELEASE6|STOP6)
+        if [ -z "${old_ip6_address}" ] || [ -z "${old_ip6_prefixlen}" ]; then
+            exit 2
+        fi
+
+        ip -6 addr del ${old_ip6_address}/${old_ip6_prefixlen} \
+            dev ${interface}
+
+        exit 0
+        ;;
+
+    EXPIRE|FAIL|RELEASE|STOP)
+        if [ -n "${alias_ip_address}" ]; then
+            # Flush alias
+            ip -4 addr flush dev ${interface} label ${interface}:0 >/dev/null 2>&1
+        fi
+
+        # upstream script sets interface down here,
+        # we only remove old ip address
+        #flush_dev ${interface}
+        remove_old_addr
+
+        if [ -n "${alias_ip_address}" ]; then
+            ip -4 addr add ${alias_ip_address}/${alias_prefix} broadcast ${alias_broadcast_address} dev ${interface} label ${interface}:0
+            ip -4 route replace ${alias_ip_address}/32 dev ${interface}
+        fi
+
+        exit 0
+        ;;
+
+    TIMEOUT)
+        if [ -n "${new_routers}" ]; then
+            if [ -n "${alias_ip_address}" ]; then
+                ip -4 addr flush dev ${interface} label ${interface}:0 >/dev/null 2>&1
+            fi
+
+            ip -4 addr add ${new_ip_address}/${new_prefix} \
+                broadcast ${new_broadcast_address} dev ${interface} \
+                valid_lft ${new_dhcp_lease_time} preferred_lft ${new_dhcp_lease_time}
+            set ${new_routers}
+
+            if ping -q -c 1 -w 10 -I ${interface} ${1}; then
+                dhconfig
+                exit 0
+            fi
+
+            #flush_dev ${interface}
+            remove_old_addr
+            exit 1
+        else
+            exit 1
+        fi
+        ;;
+
+    *)
+        logmessage "unhandled state: ${reason}"
+        exit 1
+        ;;
+esac
+
+exit 0
+

--- a/ipvlan/bin/openshift-ipvlan-kube-subnet-setup.sh
+++ b/ipvlan/bin/openshift-ipvlan-kube-subnet-setup.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+set -ex
+
+## docker
+if [[ -z "${DOCKER_OPTIONS}" ]]
+then
+    DOCKER_OPTIONS='-b=none --selinux-enabled'
+fi
+
+if ! grep -q "^OPTIONS='${DOCKER_OPTIONS}'" /etc/sysconfig/docker
+then
+    cat <<EOF > /etc/sysconfig/docker
+# This file has been modified by openshift-sdn. Please modify the
+# DOCKER_OPTIONS variable in the /etc/sysconfig/openshift-sdn-node,
+# /etc/sysconfig/openshift-sdn-master or /etc/sysconfig/openshift-sdn
+# files (depending on your setup).
+
+OPTIONS='${DOCKER_OPTIONS}'
+EOF
+fi
+systemctl daemon-reload
+systemctl restart docker.service
+
+mkdir -p /etc/openshift-sdn

--- a/ipvlan/bin/openshift-ipvlan-subnet
+++ b/ipvlan/bin/openshift-ipvlan-subnet
@@ -1,0 +1,76 @@
+#!/bin/bash
+set -ex
+
+action=$1
+pod_namespace=$2
+pod_name=$3
+net_container=$4
+
+source /etc/openshift-sdn/config.env
+private_ipam_server=${OPENSHIFT_PRIVATE_IPAM_SERVER}
+public_ipam_server=${OPENSHIFT_PUBLIC_IPAM_SERVER}
+public_gateway=${OPENSHIFT_PUBLIC_GATEWAY}
+
+Init() {
+    true
+}
+
+Setup() {
+    pid=$(docker inspect --format "{{.State.Pid}}" ${net_container})
+    private_ip_and_prefix=$(curl ${private_ipam_server}/netutils/ip/)
+    ipvldev=cont${pid}
+
+    # find the interface the default route is pointed at, and make a
+    # ipvlan interface for the container that will be assigned the
+    # container's private IP address
+    defintf=$(ip -4 route | grep default | cut -d' ' -f5)
+    ip link add link ${defintf} ${ipvldev} type ipvlan mode l${OPENSHIFT_IPVLAN_LAYER}
+    ip link set ${ipvldev} up
+
+    mkdir -p /var/run/netns
+    ln -s /proc/$pid/ns/net /var/run/netns/$pid
+    ip link set ${ipvldev} netns $pid
+    ip netns exec $pid ip link set dev ${ipvldev} name eth0
+    ip netns exec $pid ip link set dev eth0 up
+    ip netns exec $pid ip addr add ${private_ip_and_prefix} dev eth0
+    ip netns exec $pid ip link set eth0 up
+
+    if [ -n "${public_ipam_server}" ]; then
+        public_ip_and_prefix=$(curl ${public_ipam_server}/netutils/ip/)
+        ip netns exec $pid ip addr add ${public_ip_and_prefix} dev eth0 label eth0:public
+        ip netns exec $pid ip route add default dev eth0 via ${public_gateway}
+    else
+        # Get a DHCP lease for external network connectivity
+        ip netns exec $pid /sbin/dhclient -B -4 -1 -v -sf /usr/bin/openshift-ipvlan-dhclient-script -pf /run/dhclient-$pid.pid -C ${net_container} eth0
+    fi
+}
+
+Teardown() {
+    pid=$(docker inspect --format "{{.State.Pid}}" ${net_container})
+    tmp=(`ip -o addr show dev eth0 | grep eth0:public`) || true
+    if [ -n "$tmp" ]; then
+        public_ip_and_prefix=${tmp[2]}
+        curl -X DELETE ${public_ipam_server}/netutils/ip/${public_ip_and_prefix} || true
+    else
+        ip netns exec $pid /sbin/dhclient -r -sf /usr/bin/openshift-ipvlan-dhclient-script -pf /run/dhclient-${pid}.pid eth0
+    fi
+    ip netns exec $pid ip link set dev eth0 down
+    ip netns exec $pid ip link del eth0
+    rm -f /var/run/netns/$pid
+}
+
+case "$action" in
+    init)
+	Init
+	;;
+    setup)
+	Setup
+	;;
+    teardown)
+	Teardown
+	;;
+    *)
+        echo "Bad input: $@"
+        exit 1
+esac
+

--- a/ipvlan/common.go
+++ b/ipvlan/common.go
@@ -1,0 +1,328 @@
+package ipvlan
+
+import (
+	"errors"
+	"fmt"
+	log "github.com/golang/glog"
+	"net"
+	"os"
+	"os/exec"
+	"time"
+
+	"github.com/openshift/openshift-sdn/pkg/api"
+	"github.com/openshift/openshift-sdn/pkg/netutils"
+
+	netutils_server "github.com/openshift/openshift-sdn/pkg/netutils/server"
+)
+
+type IpvlanController struct {
+	subnetRegistry  api.SubnetRegistry
+	localIP         string
+	localSubnet     *api.Subnet
+	hostName        string
+	subnetAllocator *netutils.SubnetAllocator
+	sig             chan struct{}
+	layer           uint
+	pubnetServer    api.PubnetRegistryServer
+	pubnetClient    api.PubnetRegistryClient
+}
+
+func NewIpvlanController(sub api.SubnetRegistry,
+	hostname string,
+	selfIP string,
+	layer uint,
+	pubnetServer api.PubnetRegistryServer,
+	pubnetClient api.PubnetRegistryClient) (*IpvlanController, error) {
+	if selfIP == "" {
+		addrs, err := net.LookupIP(hostname)
+		if err != nil {
+			log.Errorf("Failed to lookup IP Address for %s", hostname)
+			return nil, err
+		}
+		selfIP = addrs[0].String()
+	}
+	log.Infof("Self IP: %s.", selfIP)
+
+	if pubnetServer != nil || pubnetClient != nil {
+		return &IpvlanController{
+			subnetRegistry:  sub,
+			localIP:         selfIP,
+			hostName:        hostname,
+			localSubnet:     nil,
+			subnetAllocator: nil,
+			sig:             make(chan struct{}),
+			layer:           layer,
+			pubnetServer:    pubnetServer,
+			pubnetClient:    pubnetClient,
+		}, nil
+	} else if layer == 3 {
+		return nil, fmt.Errorf("ipvlan layer3 requires the publicNetwork option")
+	}
+
+	// Layer2 DHCP
+	return &IpvlanController{
+		subnetRegistry:  sub,
+		localIP:         selfIP,
+		hostName:        hostname,
+		localSubnet:     nil,
+		subnetAllocator: nil,
+		sig:             make(chan struct{}),
+		layer:           2,
+	}, nil
+}
+
+func (self *IpvlanController) StartMaster(sync bool, containerNetwork string, containerSubnetLength uint) error {
+	// wait a minute for etcd to come alive
+	status := self.subnetRegistry.CheckEtcdIsAlive(60)
+	if !status {
+		log.Errorf("Etcd not running?")
+		return errors.New("Etcd not reachable. Sync cluster check failed.")
+	}
+	// initialize the minion key
+	if sync {
+		err := self.subnetRegistry.InitMinions()
+		if err != nil {
+			log.Infof("Minion path already initialized.")
+		}
+	}
+
+	// initialize the subnet key?
+	err := self.subnetRegistry.InitSubnets()
+	subrange := make([]string, 0)
+	if err != nil {
+		subnets, err := self.subnetRegistry.GetSubnets()
+		if err != nil {
+			log.Errorf("Error in initializing/fetching subnets: %v", err)
+			return err
+		}
+		for _, sub := range *subnets {
+			subrange = append(subrange, sub.Sub)
+		}
+	}
+
+	err = self.subnetRegistry.WriteNetworkConfig(containerNetwork, containerSubnetLength)
+	if err != nil {
+		return err
+	}
+
+	self.subnetAllocator, err = netutils.NewSubnetAllocator(containerNetwork, containerSubnetLength, subrange)
+	if err != nil {
+		return err
+	}
+
+	err = self.ServeExistingMinions()
+	if err != nil {
+		log.Warningf("Error initializing existing minions: %v", err)
+		// no worry, we can still keep watching it.
+	}
+	go self.watchMinions()
+
+	log.Infof("Starting Public Network IPAM on local IP " + self.localIP)
+	self.pubnetServer.Start(self.localIP)
+
+	return nil
+}
+
+func (self *IpvlanController) ServeExistingMinions() error {
+	minions, err := self.subnetRegistry.GetMinions()
+	if err != nil {
+		return err
+	}
+
+	for _, minion := range *minions {
+		_, err := self.subnetRegistry.GetSubnet(minion)
+		if err == nil {
+			// subnet already exists, continue
+			continue
+		}
+		err = self.AddNode(minion)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (self *IpvlanController) AddNode(minion string) error {
+	sn, err := self.subnetAllocator.GetNetwork()
+	if err != nil {
+		log.Errorf("Error creating network for minion %s.", minion)
+		return err
+	}
+	var minionIP string
+	ip := net.ParseIP(minion)
+	if ip == nil {
+		addrs, err := net.LookupIP(minion)
+		if err != nil {
+			log.Errorf("Failed to lookup IP address for minion %s: %v", minion, err)
+			return err
+		}
+		minionIP = addrs[0].String()
+		if minionIP == "" {
+			return fmt.Errorf("Failed to obtain IP address from minion label: %s", minion)
+		}
+	} else {
+		minionIP = ip.String()
+	}
+	sub := &api.Subnet{
+		Minion: minionIP,
+		Sub:    sn.String(),
+	}
+	self.subnetRegistry.CreateSubnet(minion, sub)
+	if err != nil {
+		log.Errorf("Error writing subnet to etcd for minion %s: %v", minion, sn)
+		return err
+	}
+	return nil
+}
+
+func (self *IpvlanController) DeleteNode(minion string) error {
+	sub, err := self.subnetRegistry.GetSubnet(minion)
+	if err != nil {
+		log.Errorf("Error fetching subnet for minion %s for delete operation.", minion)
+		return err
+	}
+	_, ipnet, err := net.ParseCIDR(sub.Sub)
+	if err != nil {
+		log.Errorf("Error parsing subnet for minion %s for deletion: %s", minion, sub.Sub)
+		return err
+	}
+	self.subnetAllocator.ReleaseNetwork(ipnet)
+	return self.subnetRegistry.DeleteSubnet(minion)
+}
+
+func (self *IpvlanController) syncWithMaster() error {
+	return self.subnetRegistry.CreateMinion(self.hostName, self.localIP)
+}
+
+func (self *IpvlanController) manageLocalIpam(ipnet *net.IPNet, containerNetwork string) (string, error) {
+	ipamHost := "127.0.0.1"
+	ipamPort := uint(9080)
+
+	inuse := make([]string, 0)
+	ipam, err := netutils.NewIPAllocator(ipnet.String(), inuse)
+	if err != nil {
+		return "", err
+	}
+
+	// listen and serve does not return the control
+	go netutils_server.ListenAndServeNetutilServer(ipam, net.ParseIP(ipamHost), ipamPort, nil)
+	return "http://" + ipamHost + ":9080", nil
+}
+
+func (self *IpvlanController) StartNode(sync, skipsetup bool) error {
+	if sync {
+		err := self.syncWithMaster()
+		if err != nil {
+			log.Errorf("Failed to register with master: %v", err)
+			return err
+		}
+	}
+	err := self.initSelfSubnet()
+	if err != nil {
+		log.Errorf("Failed to get subnet for this host: %v", err)
+		return err
+	}
+
+	if !skipsetup {
+		// Assume we are working with IPv4
+		containerNetwork, err := self.subnetRegistry.GetContainerNetwork()
+		if err != nil {
+			log.Errorf("Failed to obtain ContainerNetwork: %v", err)
+			return err
+		}
+
+		out, err := exec.Command("openshift-ipvlan-kube-subnet-setup.sh").CombinedOutput()
+		log.Infof("Output of setup script:\n%s", out)
+		if err != nil {
+			log.Errorf("Error executing setup script. \n\tOutput: %s\n\tError: %v\n", out, err)
+			return err
+		}
+
+		// Container network IPAM
+		_, ipnet, err := net.ParseCIDR(self.localSubnet.Sub)
+		if err != nil {
+			return err
+		}
+		privateUri, err := self.manageLocalIpam(ipnet, containerNetwork)
+		if err != nil {
+			return err
+		}
+
+		f, err := os.Create("/etc/openshift-sdn/config.env")
+		if err != nil {
+			return err
+		}
+		_, err = f.WriteString(fmt.Sprintf("OPENSHIFT_PRIVATE_IPAM_SERVER=%s\n", privateUri))
+		if err != nil {
+			return err
+		}
+		_, err = f.WriteString(fmt.Sprintf("OPENSHIFT_IPVLAN_LAYER=%d\n", self.layer))
+		if err != nil {
+			return err
+		}
+
+		if self.pubnetClient != nil {
+			// Public network IPAM
+			publicUri, publicGateway, err := self.pubnetClient.GetServerUriAndGateway()
+			if err != nil {
+				return err
+			}
+
+			if publicUri != "" && publicGateway != "" {
+				_, err = f.WriteString(fmt.Sprintf("OPENSHIFT_PUBLIC_IPAM_SERVER=%s\nOPENSHIFT_PUBLIC_GATEWAY=%s\n", publicUri, publicGateway))
+				if err != nil {
+					return err
+				}
+			}
+		}
+
+		f.Close()
+	}
+	return err
+}
+
+func (self *IpvlanController) initSelfSubnet() error {
+	// get subnet for self
+	for {
+		sub, err := self.subnetRegistry.GetSubnet(self.hostName)
+		if err != nil {
+			log.Errorf("Could not find an allocated subnet for minion %s: %s. Waiting...", self.hostName, err)
+			time.Sleep(2 * time.Second)
+			continue
+		}
+		self.localSubnet = sub
+		return nil
+	}
+}
+
+func (self *IpvlanController) watchMinions() {
+	// watch latest?
+	stop := make(chan bool)
+	minevent := make(chan *api.MinionEvent)
+	go self.subnetRegistry.WatchMinions(minevent, stop)
+	for {
+		select {
+		case ev := <-minevent:
+			switch ev.Type {
+			case api.Added:
+				_, err := self.subnetRegistry.GetSubnet(ev.Minion)
+				if err != nil {
+					// subnet does not exist already
+					self.AddNode(ev.Minion)
+				}
+			case api.Deleted:
+				self.DeleteNode(ev.Minion)
+			}
+		case <-self.sig:
+			log.Error("Signal received. Stopping watching of minions.")
+			stop <- true
+			return
+		}
+	}
+}
+
+func (self *IpvlanController) Stop() {
+	close(self.sig)
+	//self.sig <- struct{}{}
+}

--- a/main.go
+++ b/main.go
@@ -96,17 +96,15 @@ func newSubnetRegistry() (api.SubnetRegistry, error) {
 		minionPath = path.Join(opts.etcdPath, "minions")
 	}
 
-	cfg := &registry.EtcdConfig{
-		Endpoints:        peers,
-		Keyfile:          opts.etcdKeyfile,
-		Certfile:         opts.etcdCertfile,
-		CAFile:           opts.etcdCAFile,
-		SubnetPath:       subnetPath,
-		SubnetConfigPath: subnetConfigPath,
-		MinionPath:       minionPath,
+	cfg := &api.EtcdConfig{
+		Endpoints: peers,
+		Keyfile:   opts.etcdKeyfile,
+		Certfile:  opts.etcdCertfile,
+		CAFile:    opts.etcdCAFile,
+		Path:      opts.etcdPath,
 	}
 
-	return registry.NewEtcdSubnetRegistry(cfg)
+	return registry.NewEtcdSubnetRegistry(cfg, subnetPath, subnetConfigPath, minionPath)
 }
 
 func main() {

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -49,3 +49,11 @@ type Subnet struct {
 	Minion string
 	Sub    string
 }
+
+type PubnetRegistryServer interface {
+	Start(ipAddress string) error
+}
+
+type PubnetRegistryClient interface {
+	GetServerUriAndGateway() (string, string, error)
+}

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -7,6 +7,14 @@ const (
 	Deleted EventType = "DELETED"
 )
 
+type EtcdConfig struct {
+	Endpoints []string
+	Keyfile   string
+	Certfile  string
+	CAFile    string
+	Path      string
+}
+
 type SubnetRegistry interface {
 	InitSubnets() error
 	GetSubnets() (*[]Subnet, error)

--- a/pkg/netutils/ip_allocator.go
+++ b/pkg/netutils/ip_allocator.go
@@ -3,6 +3,7 @@ package netutils
 import (
 	"fmt"
 	"net"
+	"strconv"
 )
 
 type IPAllocator struct {
@@ -33,6 +34,56 @@ func NewIPAllocator(network string, inUse []string) (*IPAllocator, error) {
 	// Add the network address to the map
 	amap[netIP.String()] = true
 	return &IPAllocator{network: netIP, allocMap: amap}, nil
+}
+
+func nextIP(ip net.IP) {
+	for j := len(ip) - 1; j >= 0; j-- {
+		ip[j]++
+		if ip[j] > 0 {
+			break
+		}
+	}
+}
+
+func NewIPAllocatorBounded(network string, begin string, end string) (*IPAllocator, error) {
+	_, ipnet, err := net.ParseCIDR(network)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to parse network address: ", network)
+	}
+
+	beginIP := net.ParseIP(begin)
+	if beginIP == nil {
+		return nil, fmt.Errorf("Failed to parse beginning network address: ", begin)
+	}
+	if !ipnet.Contains(beginIP) {
+		return nil, fmt.Errorf("Begining IP doesn't belong to network: ", begin)
+	}
+
+	endIP := net.ParseIP(end)
+	if endIP == nil {
+		return nil, fmt.Errorf("Failed to parse ending network address: ", end)
+	}
+	if !ipnet.Contains(endIP) {
+		return nil, fmt.Errorf("Ending IP doesn't belong to network: ", end)
+	}
+
+	prefixSize, _ := ipnet.Mask.Size()
+	prefix := strconv.FormatUint(uint64(prefixSize), 10)
+
+	amap := make(map[string]bool)
+	for ip := beginIP.Mask(ipnet.Mask); ipnet.Contains(ip); nextIP(ip) {
+		if ip.String() == begin {
+			break
+		}
+		amap[ip.String()+"/"+prefix] = true
+	}
+	// Advance one past end IP
+	nextIP(endIP)
+	for ip := endIP; ipnet.Contains(ip); nextIP(ip) {
+		amap[ip.String()+"/"+prefix] = true
+	}
+
+	return &IPAllocator{network: ipnet, allocMap: amap}, nil
 }
 
 func (ipa *IPAllocator) GetIP() (*net.IPNet, error) {

--- a/pkg/registry/etcd_client.go
+++ b/pkg/registry/etcd_client.go
@@ -1,0 +1,99 @@
+package registry
+
+import (
+	"fmt"
+	"path"
+	"sync"
+	"time"
+
+	"github.com/coreos/go-etcd/etcd"
+	log "github.com/golang/glog"
+	"github.com/openshift/openshift-sdn/pkg/api"
+)
+
+type EtcdClient struct {
+	mux sync.Mutex
+	cli *etcd.Client
+	cfg *api.EtcdConfig
+}
+
+func newEtcdClient(cfg *api.EtcdConfig) (*etcd.Client, error) {
+	if cfg.Keyfile != "" || cfg.Certfile != "" || cfg.CAFile != "" {
+		return etcd.NewTLSClient(cfg.Endpoints, cfg.Certfile, cfg.Keyfile, cfg.CAFile)
+	} else {
+		return etcd.NewClient(cfg.Endpoints), nil
+	}
+}
+
+func NewEtcdClient(cfg *api.EtcdConfig) (*EtcdClient, error) {
+	cli, err := newEtcdClient(cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	return &EtcdClient{
+		cli: cli,
+		cfg: cfg,
+	}, nil
+}
+
+func (self *EtcdClient) CheckEtcdIsAlive(seconds uint64) bool {
+	for {
+		status := self.client().SyncCluster()
+		log.Infof("Etcd cluster status: %v", status)
+		if status {
+			return status
+		}
+		if seconds <= 0 {
+			break
+		}
+		time.Sleep(5 * time.Second)
+		seconds -= 5
+	}
+	return false
+}
+
+func (self *EtcdClient) watch(key string, rev uint64, stop chan bool) (*etcd.Response, error) {
+	rawResp, err := self.client().RawWatch(key, rev, true, nil, stop)
+
+	if err != nil {
+		if err == etcd.ErrWatchStoppedByUser {
+			return nil, err
+		} else {
+			log.Warningf("Temporary error while watching %s: %v\n", key, err)
+			time.Sleep(time.Second)
+			self.resetClient()
+			return nil, nil
+		}
+	}
+
+	if len(rawResp.Body) == 0 {
+		// etcd timed out, go back but recreate the client as the underlying
+		// http transport gets hosed (http://code.google.com/p/go/issues/detail?id=8648)
+		self.resetClient()
+		return nil, nil
+	}
+
+	return rawResp.Unmarshal()
+}
+
+func (self *EtcdClient) client() *etcd.Client {
+	self.mux.Lock()
+	defer self.mux.Unlock()
+	return self.cli
+}
+
+func (self *EtcdClient) resetClient() {
+	self.mux.Lock()
+	defer self.mux.Unlock()
+
+	var err error
+	self.cli, err = newEtcdClient(self.cfg)
+	if err != nil {
+		panic(fmt.Errorf("resetClient: error recreating etcd client: %v", err))
+	}
+}
+
+func (self *EtcdClient) getKeyPath(key string) string {
+	return path.Join(self.cfg.Path, key)
+}

--- a/pkg/registry/pubnet_registry.go
+++ b/pkg/registry/pubnet_registry.go
@@ -1,0 +1,170 @@
+package registry
+
+import (
+	"fmt"
+	log "github.com/golang/glog"
+	"net"
+	"strings"
+
+	"github.com/coreos/go-etcd/etcd"
+	"github.com/openshift/openshift-sdn/pkg/api"
+	"github.com/openshift/openshift-sdn/pkg/netutils"
+	netutils_server "github.com/openshift/openshift-sdn/pkg/netutils/server"
+)
+
+type PubnetIpam struct {
+	pnIpam  *netutils.IPAllocator
+	gateway string
+	cli     *EtcdClient
+}
+
+func NewPubnetServer(config *api.EtcdConfig, publicNetwork string) (api.PubnetRegistryServer, error) {
+	var ipam *netutils.IPAllocator
+	var gateway string
+
+	if publicNetwork != "" {
+		net, begin, end, gw, err := parsePublicNetwork(publicNetwork)
+		if err != nil {
+			return nil, err
+		}
+		ipam, err = netutils.NewIPAllocatorBounded(net.String(), begin, end)
+		if err != nil {
+			return nil, err
+		}
+		gateway = gw
+	}
+
+	cli, err := NewEtcdClient(config)
+	if err != nil {
+		return nil, err
+	}
+
+	return &PubnetIpam{
+		pnIpam:  ipam,
+		gateway: gateway,
+		cli:     cli,
+	}, nil
+}
+
+func NewPubnetClient(config *api.EtcdConfig) (api.PubnetRegistryClient, error) {
+	cli, err := NewEtcdClient(config)
+	if err != nil {
+		return nil, err
+	}
+
+	return &PubnetIpam{
+		cli: cli,
+	}, nil
+}
+
+func parsePublicNetwork(publicNetwork string) (*net.IPNet, string, string, string, error) {
+	a := strings.Split(publicNetwork, "-")
+	if len(a) < 2 {
+		return nil, "", "", "", fmt.Errorf("publicNetwork had no '-' separator")
+	}
+	b := strings.Split(a[1], "/")
+	if len(b) < 2 {
+		return nil, "", "", "", fmt.Errorf("publicNetwork had no '/' separator")
+	}
+	pnBegin := a[0]
+	pnEnd := b[0]
+
+	c := strings.Split(b[1], "+")
+	if len(b) < 2 {
+		return nil, "", "", "", fmt.Errorf("publicNetwork had no '+' separator")
+	}
+	prefix := c[0]
+	gateway := c[1]
+
+	_, pnNet, err := net.ParseCIDR(pnBegin + "/" + prefix)
+	if err != nil {
+		return nil, "", "", "", err
+	}
+	endIp, _, err := net.ParseCIDR(pnEnd + "/" + prefix)
+	if err != nil {
+		return nil, "", "", "", err
+	}
+	if !pnNet.Contains(endIp) {
+		return nil, "", "", "", fmt.Errorf("publicNetwork end IP not contained in start IP network")
+	}
+
+	gwIP := net.ParseIP(gateway)
+	if gwIP == nil {
+		return nil, "", "", "", fmt.Errorf("publicNetwork had no gateway")
+	}
+
+	return pnNet, pnBegin, pnEnd, gateway, nil
+}
+
+func (self *PubnetIpam) Start(ipAddress string) error {
+	addr := net.ParseIP(ipAddress)
+	if addr == nil {
+		return fmt.Errorf("Failed to parse server IP address: ", ipAddress)
+	}
+
+	serverKey := self.cli.getKeyPath("PublicNetworkIpamServer")
+	gatewayKey := self.cli.getKeyPath("PublicNetworkGateway")
+
+	if self.pnIpam == nil {
+		// Disable public network IPAM
+		self.cli.client().Delete(serverKey, false)
+		self.cli.client().Delete(gatewayKey, false)
+		return nil
+	}
+
+	uri := "http://" + ipAddress + ":9081"
+	_, err := self.cli.client().Create(serverKey, uri, 0)
+	if err != nil {
+		log.Warningf("Found existing network configuration, overwriting it.")
+		_, err = self.cli.client().Update(serverKey, uri, 0)
+		if err != nil {
+			log.Errorf("Failed to write Network configuration to etcd: %v", err)
+			return err
+		}
+	}
+
+	_, err = self.cli.client().Create(gatewayKey, self.gateway, 0)
+	if err != nil {
+		log.Warningf("Found existing gateway, overwriting it.")
+		_, err = self.cli.client().Update(gatewayKey, self.gateway, 0)
+		if err != nil {
+			log.Errorf("Failed to write gateway to etcd: %v", err)
+			return err
+		}
+	}
+
+	// listen and serve does not return the control
+	go netutils_server.ListenAndServeNetutilServer(self.pnIpam, addr, uint(9081), nil)
+
+	return nil
+}
+
+func (self *PubnetIpam) GetEtcdKey(keyName string) (string, error) {
+	key := self.cli.getKeyPath(keyName)
+
+	resp, err := self.cli.client().Get(key, false, false)
+	if err != nil {
+		// Attempt to distinguish between "key does not exist" errors and
+		// other errors talking to etcd
+		if e, ok := err.(*etcd.EtcdError); ok {
+			if e.ErrorCode == 100 {
+				return "", nil
+			}
+		}
+		return "", err
+	}
+	return resp.Node.Value, nil
+}
+
+func (self *PubnetIpam) GetServerUriAndGateway() (string, string, error) {
+	uri, err := self.GetEtcdKey("PublicNetworkIpamServer")
+	if err != nil {
+		return "", "", err
+	}
+	gw, err := self.GetEtcdKey("PublicNetworkGateway")
+	if err != nil {
+		return "", "", err
+	}
+
+	return uri, gw, nil
+}


### PR DESCRIPTION

ipvlan in general only works with 4.0 and later kernels.

ipvlan L2 + DHCP will only work reliably with 4.1 and later kernels,
and because ipvlan uses the same MAC address for all interfaces, the
DHCP server must support differentiating leases via Client ID. One
notable exception is the VirtualBox DHCP server, which does not support
Client ID and thus will not work with ipvlan L2 + DHCP.

This patch changes the '-kube' option into a '-kubenet' option that
accepts a couple different networking plugins. In addition to the
previous '-kubenet=kube' option this commit adds '-kubenet=ipvlan-l2'
and '-kubenet=ipvlan-l3' options. In all ipvlan configurations
the pod gets a single ipvlan interface created as a child of the
physical NIC on the minion that has the defualt route. The pod-private
IP address and a publicly routable IP address are both assigned to
the ipvlan interface in parallel with each other.

Pod-private IP addresses work the same way for all modes. The only
difference is how the public IP address is assigned and what layer the
ipvlan operates in:

ipvlan-l2 + DHCP: the ipvlan operates at L2 and is aware of broadcast
and multicast frames from the physical LAN. The public IP address is
retrieved from the physical LAN's normal DHCP server. This requires
that the container image have the /sbin/ip and ISC dhclient binaries
available.

ipvlan-l2/ipvlan-l3 + static: the public IP address is allocated from
a pool configured on the master using the --public-network option of
openshift-sdn like so:

`--public-network=<start>-<stop>/<prefix>+<gateway>`

The URL of the master's public network IPAM is saved in etcd and read
on from each minion when the pod is started.
