### PR TITLE
Don't persist docker network configuration when the sdn hasn't been started

### DIFF
--- a/openshift-sdn.spec
+++ b/openshift-sdn.spec
@@ -87,6 +87,8 @@ mkdir -p %{buildroot}%{_sysconfdir}/sysconfig
 install -m 0644 rel-eng/openshift-sdn-master.sysconfig %{buildroot}%{_sysconfdir}/sysconfig/openshift-sdn-master
 install -m 0644 rel-eng/openshift-sdn-node.sysconfig %{buildroot}%{_sysconfdir}/sysconfig/openshift-sdn-node
 
+install -d -m 0755 %{buildroot}%{_prefix}/lib/systemd/system/docker.service.d
+install -p -m 0644 rel-eng/docker-sdn-ovs.conf %{buildroot}%{_prefix}/lib/systemd/system/docker.service.d/
 
 %files
 %defattr(-,root,root,-)
@@ -116,8 +118,10 @@ install -m 0644 rel-eng/openshift-sdn-node.sysconfig %{buildroot}%{_sysconfdir}/
 %defattr(-,root,root,-)
 %{_unitdir}/openshift-sdn-node.service
 %config(noreplace) %{_sysconfdir}/sysconfig/openshift-sdn-node
+%{_prefix}/lib/systemd/system/docker.service.d/
 
 %post node
+systemctl daemon-reload
 %systemd_post %{basename:openshift-sdn-node.service}
 
 %preun node

--- a/ovssubnet/bin/openshift-sdn-kube-subnet-setup.sh
+++ b/ovssubnet/bin/openshift-sdn-kube-subnet-setup.sh
@@ -72,9 +72,8 @@ function setup() {
         DOCKER_NETWORK_OPTIONS='-b=lbr0 --mtu=1450'
     fi
 
-    if ! grep -q "^DOCKER_NETWORK_OPTIONS='${DOCKER_NETWORK_OPTIONS}'" /etc/sysconfig/docker-network
-    then
-        cat <<EOF > /etc/sysconfig/docker-network
+    mkdir -p /run/openshift-sdn
+    cat <<EOF > /run/openshift-sdn/docker-network
 # This file has been modified by openshift-sdn. Please modify the
 # DOCKER_NETWORK_OPTIONS variable in /etc/sysconfig/openshift-node if this
 # is an integrated install or /etc/sysconfig/openshift-sdn-node if this is a
@@ -82,7 +81,7 @@ function setup() {
 
 DOCKER_NETWORK_OPTIONS='${DOCKER_NETWORK_OPTIONS}'
 EOF
-    fi
+
     systemctl daemon-reload
     systemctl restart docker.service
 

--- a/ovssubnet/bin/openshift-sdn-kube-subnet-setup.sh
+++ b/ovssubnet/bin/openshift-sdn-kube-subnet-setup.sh
@@ -76,9 +76,9 @@ function setup() {
     then
         cat <<EOF > /etc/sysconfig/docker-network
 # This file has been modified by openshift-sdn. Please modify the
-# DOCKER_NETWORK_OPTIONS variable in the /etc/sysconfig/openshift-sdn-node,
-# /etc/sysconfig/openshift-sdn-master or /etc/sysconfig/openshift-sdn
-# files (depending on your setup).
+# DOCKER_NETWORK_OPTIONS variable in /etc/sysconfig/openshift-node if this
+# is an integrated install or /etc/sysconfig/openshift-sdn-node if this is a
+# standalone install.
 
 DOCKER_NETWORK_OPTIONS='${DOCKER_NETWORK_OPTIONS}'
 EOF

--- a/ovssubnet/bin/openshift-sdn-simple-setup-node.sh
+++ b/ovssubnet/bin/openshift-sdn-simple-setup-node.sh
@@ -55,9 +55,9 @@ if ! grep -q "^DOCKER_NETWORK_OPTIONS='${DOCKER_NETWORK_OPTIONS}'" /etc/sysconfi
 then
     cat <<EOF > /etc/sysconfig/docker-network
 # This file has been modified by openshift-sdn. Please modify the
-# DOCKER_NETWORK_OPTIONS variable in the /etc/sysconfig/openshift-sdn-node,
-# /etc/sysconfig/openshift-sdn-master or /etc/sysconfig/openshift-sdn
-# files (depending on your setup).
+# DOCKER_NETWORK_OPTIONS variable in /etc/sysconfig/openshift-node if this
+# is an integrated install or /etc/sysconfig/openshift-sdn-node if this is a
+# standalone install.
 
 DOCKER_NETWORK_OPTIONS='${DOCKER_NETWORK_OPTIONS}'
 EOF

--- a/ovssubnet/bin/openshift-sdn-simple-setup-node.sh
+++ b/ovssubnet/bin/openshift-sdn-simple-setup-node.sh
@@ -51,9 +51,8 @@ then
     DOCKER_NETWORK_OPTIONS='-b=lbr0 --mtu=1450'
 fi
 
-if ! grep -q "^DOCKER_NETWORK_OPTIONS='${DOCKER_NETWORK_OPTIONS}'" /etc/sysconfig/docker-network
-then
-    cat <<EOF > /etc/sysconfig/docker-network
+mkdir -p /run/openshift-sdn
+cat <<EOF > /run/openshift-sdn/docker-network
 # This file has been modified by openshift-sdn. Please modify the
 # DOCKER_NETWORK_OPTIONS variable in /etc/sysconfig/openshift-node if this
 # is an integrated install or /etc/sysconfig/openshift-sdn-node if this is a
@@ -61,6 +60,6 @@ then
 
 DOCKER_NETWORK_OPTIONS='${DOCKER_NETWORK_OPTIONS}'
 EOF
-fi
+
 systemctl daemon-reload
 systemctl restart docker.service

--- a/rel-eng/docker-sdn-ovs.conf
+++ b/rel-eng/docker-sdn-ovs.conf
@@ -1,0 +1,2 @@
+[Service]
+EnvironmentFile=-/run/openshift-sdn/docker-network


### PR DESCRIPTION
This moves docker network configuration environment variables to a tmpfs file `/run/openshift-sdn/docker-network` rather than persisting it in `/etc/sysconfig/docker-network` The values are then injected into the docker service by loading that as an optional environment file in a docker.service config file installed by openshift-sdn-node at `/usr/lib/systemd/system/docker.service.d/docker-sdn-ovs.conf`

`/run/openshift-sdn/docker-network` is removed at reboot because it's tmpfs and when openshift-sdn-node service is shut down ensuring that when the sdn isn't running everything works.