### PR TITLE
fix issue#88 - generate unique cookie based on vtep

### DIFF
--- a/ovssubnet/controller/kube/kube.go
+++ b/ovssubnet/controller/kube/kube.go
@@ -1,7 +1,7 @@
 package kube
 
 import (
-	"crypto/md5"
+	"encoding/hex"
 	"fmt"
 	log "github.com/golang/glog"
 	"net"
@@ -119,5 +119,5 @@ func (c *FlowController) DelOFRules(minion, localIP string) error {
 }
 
 func generateCookie(ip string) string {
-	return strconv.FormatInt(int64(md5.Sum([]byte(ip))[0]), 16)
+	return hex.EncodeToString(net.ParseIP(ip).To4())
 }

--- a/ovssubnet/controller/lbr/lbr.go
+++ b/ovssubnet/controller/lbr/lbr.go
@@ -1,7 +1,7 @@
 package lbr
 
 import (
-	"crypto/md5"
+	"encoding/hex"
 	"fmt"
 	log "github.com/golang/glog"
 	"net"
@@ -77,5 +77,5 @@ func (c *FlowController) DelOFRules(minion, localIP string) error {
 }
 
 func generateCookie(ip string) string {
-	return strconv.FormatInt(int64(md5.Sum([]byte(ip))[0]), 16)
+	return hex.EncodeToString(net.ParseIP(ip).To4())
 }


### PR DESCRIPTION
Sample output of hex encoding the IP address:
Checksum '192.168.1.4': c0a80104
Checksum '192.168.1.5': c0a80105
Checksum '10.168.1.5': 0aa80105

As long as the IP address of a node is unique (which should always be the case), the cookie will be unique too.

@mrunalp Review please.
