### PR TITLE
Allow vnid=x to send to vnid=0 on the same host

### DIFF
--- a/ovssubnet/controller/multitenant/bin/openshift-ovs-multitenant
+++ b/ovssubnet/controller/multitenant/bin/openshift-ovs-multitenant
@@ -47,6 +47,9 @@ Setup() {
 
     ovs-ofctl -O OpenFlow13 add-flow br0 "table=3,cookie=0x${ovs_port},priority=100,in_port=${ovs_port},ip,nw_src=${ipaddr},actions=load:${tenant_id}->NXM_NX_REG0[],goto_table:4"
     ovs-ofctl -O OpenFlow13 add-flow br0 "table=5,cookie=0x${ovs_port},priority=100,ip,nw_dst=${ipaddr},reg0=${tenant_id},actions=output:${ovs_port}"
+    if [ "${tenant_id}" == "0" ]; then
+      ovs-ofctl -O OpenFlow13 add-flow br0 "table=5,cookie=0x${ovs_port},priority=150,ip,nw_dst=${ipaddr},actions=output:${ovs_port}"
+    fi
 
     add_subnet_route="ip route add ${cluster_subnet} dev eth0 proto kernel scope link src $ipaddr"
     nsenter -n -t $pid -- $add_subnet_route


### PR DESCRIPTION
vnid=0 can already send to any other pods on the same host or across hosts, but those pods cannot send back to vnid=0 because there is no matching rule in table 5 that allows it.  So add a rule for each vnid=0 pod (currently just the 'default' project) that allows any other pod to send packets back to it.

This makes vnid=0 a special "global" namespace that can talk to any other namespace.  Other vnids still cannot talk to other non-0 vnids however, preserving isolation between projects not named "default".