### PR TITLE
Let docker-only container global traffic through the vSwitch to tun0

### DIFF
--- a/ovssubnet/controller/multitenant/bin/openshift-sdn-multitenant-setup.sh
+++ b/ovssubnet/controller/multitenant/bin/openshift-sdn-multitenant-setup.sh
@@ -67,6 +67,8 @@ function setup() {
     ovs-ofctl -O OpenFlow13 add-flow br0 "table=2, ip, nw_dst=${subnet}, actions=move:NXM_NX_TUN_ID[0..31]->NXM_NX_REG0[], goto_table:5"
 
     # Table 3; incoming from container; filled in by openshift-ovs-subnet
+    # But let incoming traffic from docker-only containers through (ingress on vovsbr)
+    ovs-ofctl -O OpenFlow13 add-flow br0 "table=3, cookie=0x9, in_port=9, ip, actions=goto_table:4"
 
     # Table 4; general routing
     ovs-ofctl -O OpenFlow13 add-flow br0 "table=4, ip, nw_dst=${subnet_gateway}, actions=output:2"


### PR DESCRIPTION
Docker-only containers (eg, "docker run foobar") get attached to lbr0, and
their traffic flows from lbr0 -> vlinuxbr -> vovsbr -> br0.  To ensure that
docker-only containers can access the rest of the world through tun0, we
need to pass their traffic along instead of dropping it in table #3:

 cookie=0x0, duration=12307.238s, table=0, n_packets=292, n_bytes=23330, actions=learn(table=7,hard_timeout=900,priority=200,NXM_OF_ETH_DST[]=NXM_OF_ETH_SRC[],load:NXM_NX_TUN_IPV4_SRC[]->NXM_NX_TUN_IPV4_DST[],output:NXM_OF_IN_PORT[]),goto_table:1
 cookie=0x0, duration=12307.227s, table=1, n_packets=165, n_bytes=13199, actions=goto_table:3
 <drop due to no match>

Add a rule allowing traffic from vovsbr to jump from table #3 to table #4,
where it will get directed to the right place (either other pods or tun0).