### PR TITLE
make cross node services work

### DIFF
--- a/ovssubnet/controller/multitenant/bin/openshift-sdn-multitenant-setup.sh
+++ b/ovssubnet/controller/multitenant/bin/openshift-sdn-multitenant-setup.sh
@@ -63,17 +63,18 @@ function setup() {
 
     # Table 2; incoming from vxlan
     ovs-ofctl -O OpenFlow13 add-flow br0 "table=2, arp, actions=goto_table:7"
+    ovs-ofctl -O OpenFlow13 add-flow br0 "table=2, priority=200, ip, nw_dst=${subnet_gateway}, actions=output:2"
     ovs-ofctl -O OpenFlow13 add-flow br0 "table=2, tun_id=0, actions=goto_table:4"
-    ovs-ofctl -O OpenFlow13 add-flow br0 "table=2, ip, nw_dst=${subnet}, actions=move:NXM_NX_TUN_ID[0..31]->NXM_NX_REG0[], goto_table:5"
+    ovs-ofctl -O OpenFlow13 add-flow br0 "table=2, priority=100, ip, nw_dst=${subnet}, actions=move:NXM_NX_TUN_ID[0..31]->NXM_NX_REG0[], goto_table:5"
 
     # Table 3; incoming from container; filled in by openshift-ovs-subnet
     # But let incoming traffic from docker-only containers through (ingress on vovsbr)
     ovs-ofctl -O OpenFlow13 add-flow br0 "table=3, cookie=0x9, in_port=9, ip, actions=goto_table:4"
 
     # Table 4; general routing
-    ovs-ofctl -O OpenFlow13 add-flow br0 "table=4, ip, nw_dst=${subnet_gateway}, actions=output:2"
-    ovs-ofctl -O OpenFlow13 add-flow br0 "table=4, ip, nw_dst=${subnet}, actions=goto_table:5"
-    ovs-ofctl -O OpenFlow13 add-flow br0 "table=4, ip, nw_dst=${cluster_subnet}, actions=goto_table:6"
+    ovs-ofctl -O OpenFlow13 add-flow br0 "table=4, priority=200, ip, nw_dst=${subnet_gateway}, actions=output:2"
+    ovs-ofctl -O OpenFlow13 add-flow br0 "table=4, priority=150, ip, nw_dst=${subnet}, actions=goto_table:5"
+    ovs-ofctl -O OpenFlow13 add-flow br0 "table=4, priority=100, ip, nw_dst=${cluster_subnet}, actions=goto_table:6"
     ovs-ofctl -O OpenFlow13 add-flow br0 "table=4, priority=0, ip, actions=output:2"
 
     # Table 5; to local container; mostly filled in by openshift-ovs-multitenant


### PR DESCRIPTION
Services need to work across nodes. That means being able to reach a pod (any namespace) from any host. The originating node's OVS rules do not handle a swift exit for return traffic (vnid != 0) meant for tun0 (port 2, IP: subnet_gateway). 

This PR adds a special rule in table 2 (as all input traffic from vxlan port is directed to table 2) to send anything meant for the host/service/tun0 directly out (no need to flood the rest of the ports).
Could have put this rule in table 5 also where all the rest of ports decide on which packet is whose, but why jump an extra table.


Also add priority to rules where the matching criterion can overlap (do not assume insertion order).

@dcbw : Review please. Services from another host didnt work without this and they work with this fix.