### PR TITLE
Add support for docker-in-docker deployment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,8 @@
 OUT_DIR = _output
 OUT_PKG_DIR = Godeps/_workspace/pkg
 
+CONTROLLER_DIR = ovssubnet/controller
+
 export GOFLAGS
 
 # Build code.
@@ -39,6 +41,21 @@ install:
 	cp -f $(OUT_DIR)/local/go/bin/openshift-sdn-multitenant-setup.sh /usr/bin/
 	mkdir -p /usr/lib/systemd/system/docker.service.d/
 	cp -f rel-eng/docker-sdn-ovs.conf /usr/lib/systemd/system/docker.service.d/
+
+install-dev:
+	rm -f /usr/bin/openshift-sdn
+	rm -f /usr/bin/openshift-sdn-simple-setup-node.sh
+	cp -f $(OUT_DIR)/local/go/bin/openshift-sdn /usr/bin/
+	ln -rsf $(CONTROLLER_DIR)/lbr/bin/openshift-sdn-simple-setup-node.sh /usr/bin/
+	ln -rsf $(CONTROLLER_DIR)/kube/bin/openshift-ovs-subnet /usr/bin/
+	ln -rsf $(CONTROLLER_DIR)/kube/bin/openshift-sdn-kube-subnet-setup.sh /usr/bin/
+	mkdir -p /usr/libexec/kubernetes/kubelet-plugins/net/exec/redhat~openshift-ovs-subnet/
+	ln -rsf $(CONTROLLER_DIR)/kube/bin/openshift-ovs-subnet /usr/libexec/kubernetes/kubelet-plugins/net/exec/redhat~openshift-ovs-subnet/
+	ln -rsf $(CONTROLLER_DIR)/multitenant/bin/openshift-ovs-multitenant /usr/bin/
+	ln -rsf $(CONTROLLER_DIR)/multitenant/bin/openshift-sdn-multitenant-setup.sh /usr/bin/
+	mkdir -p /usr/lib/systemd/system/docker.service.d/
+	ln -rsf rel-eng/docker-sdn-ovs.conf /usr/lib/systemd/system/docker.service.d/
+
 
 # Remove all build artifacts.
 #

--- a/ovssubnet/controller/kube/bin/openshift-sdn-kube-subnet-setup.sh
+++ b/ovssubnet/controller/kube/bin/openshift-sdn-kube-subnet-setup.sh
@@ -83,8 +83,23 @@ function setup() {
         DOCKER_NETWORK_OPTIONS='-b=lbr0 --mtu=1450'
     fi
 
-    mkdir -p /run/openshift-sdn
-    cat <<EOF > /run/openshift-sdn/docker-network
+    # Assume supervisord-managed docker for docker-in-docker deployments
+    if [ -f /.dockerinit ]; then
+        conf=/etc/supervisord.conf
+        if [ ! -f "${conf}" ]; then
+            >&2 echo "Running in docker but /etc/supervisord.conf not found."
+            exit 1
+        fi
+        if ! grep "DOCKER_DAEMON_ARGS=\"${DOCKER_NETWORK_OPTIONS}\"" "${conf}"; then
+            >&2 echo "Docker networking options have changed; manual restart required."
+            sed -i.bak -e \
+                "s+\(DOCKER_DAEMON_ARGS=\)\"\"+\1\"${DOCKER_NETWORK_OPTIONS}\"+" \
+                "${conf}"
+        fi
+    # Otherwise assume systemd-managed docker
+    else
+        mkdir -p /run/openshift-sdn
+        cat <<EOF > /run/openshift-sdn/docker-network
 # This file has been modified by openshift-sdn. Please modify the
 # DOCKER_NETWORK_OPTIONS variable in /etc/sysconfig/openshift-node if this
 # is an integrated install or /etc/sysconfig/openshift-sdn-node if this is a
@@ -93,14 +108,18 @@ function setup() {
 DOCKER_NETWORK_OPTIONS='${DOCKER_NETWORK_OPTIONS}'
 EOF
 
-    systemctl daemon-reload
-    systemctl restart docker.service
+        systemctl daemon-reload
+        systemctl restart docker.service
 
-    # disable iptables for lbr0
-    # for kernel version 3.18+, module br_netfilter needs to be loaded upfront
-    # for older ones, br_netfilter may not exist, but is covered by bridge (bridge-utils)
-    modprobe br_netfilter || true 
-    sysctl -w net.bridge.bridge-nf-call-iptables=0
+        # disable iptables for lbr0
+        # for kernel version 3.18+, module br_netfilter needs to be loaded upfront
+        # for older ones, br_netfilter may not exist, but is covered by bridge (bridge-utils)
+        #
+        # This operation is assumed to have been performed in advance
+        # for docker-in-docker deployments.
+        modprobe br_netfilter || true
+        sysctl -w net.bridge.bridge-nf-call-iptables=0
+    fi
 
     # delete the subnet routing entry created because of lbr0
     ip route del ${subnet} dev lbr0 proto kernel scope link src ${subnet_gateway} || true


### PR DESCRIPTION
This change is intended to allow openshift-sdn to work in a docker-in-docker (dind) openshift deployment.  I would appreciate feedback before updating the other setup scripts.  I'm hopeful the change in question could be encapsulated as a bash function for reuse rather than duplicated in all the setup scripts.

To test this change with dind: 

    # Clone my openshift repo
    $ git clone https://github.com/marun/origin    
    
    $ cd origin
    
    # Check out the dind-dev branch
    $ git co -b dind-dev origin/dind-dev
    
    # Clone openshift-sdn to the root of the origin clone
    $ git clone https://github.com/marun/openshift-sdn
    
    $ cd openshift-sdn
    
    # Check out the dind-dev branch
    $ git co -b dind-dev origin/dind-dev
    
    $ cd ..

    # Deploy a dind devcluster
    # WARNING: this requires docker to be installed locally and modifies
    # the host networking state.  It is recommended that this be run
    # in a VM.
    $ hack/dind/up.sh

    # Clone my kubernetes repo
    $ git clone https://github.com/marun/kubernetes ../kubernetes

    # Check out the e2e-network-isolation branch
    $ git co -b e2e-network-isolation origin/e2e-network-isolation

    # Build kubernetes
    $ pushd ../kubernetes/build
    $ ./run.sh hack/build-go.sh
    $ popd

    # Run kube networking e2e tests
    $ KUBE_ROOT=../kubernetes hack/run-kube-e2e.sh --ginkgo.focus="Networking"