### PR TITLE
Update subnet openflow rules in case of host ip change

### DIFF
--- a/ISOLATION.md
+++ b/ISOLATION.md
@@ -17,7 +17,7 @@ See `isolation-node-interfaces-diagram.pdf` for a diagram of how all these inter
 
 #### IP Address allocation
 
-When using Vagrant to configure the cluster, the master and each node are assigned cluster-private IP addresses in the 10.245.2.x/24 subnet through statements in the Vagrantfile.  The master receives 10.245.2.2 and the minions recieve an address above that.  The cluster uses these 10.245.2.x addresses for all communication between master and nodes.  Vagrant provisioning then writes the IP addresses of the master into the master's openshift-master systemd startup script, the configuration files passed to each openshift node process with --config, each node's 'kubeconfig' (referenced from the nodes --config YAML file), and each node's /etc/hosts file.
+When using Vagrant to configure the cluster, the master and each node are assigned cluster-private IP addresses in the 10.245.2.x/24 subnet through statements in the Vagrantfile.  The master receives 10.245.2.2 and the nodes recieve an address above that.  The cluster uses these 10.245.2.x addresses for all communication between master and nodes.  Vagrant provisioning then writes the IP addresses of the master into the master's openshift-master systemd startup script, the configuration files passed to each openshift node process with --config, each node's 'kubeconfig' (referenced from the nodes --config YAML file), and each node's /etc/hosts file.
 
 When manual or other provisioning is used, the nodes must be told of the master's IP address through the --config argument and/or the kubeconfig files.  The master must be told its IP address with the --master argument.
 
@@ -45,5 +45,5 @@ The most interesting pieces of the multitenant plugin are:
 
 * **ovssubnet/controller/multitenant/bin/openshift-sdn-multitenant-setup.sh**: this script is run every time the openshift-node process starts or stops.  It does initial setup, like configuring the lbr0 bridge, adding the OVS bridge, adding the OVS VXLAN port, setting up the tun0 port and NAT rules, and configuring the non-pod-specific OVS rules.
 
-* **ovssubnet/controller/multitenant/multitenant.go**: this module watches etcd for indications of minions added to or removed from the cluster, and updates the OVS rules to ensure each minion can be reached through the VXLAN tunnel.
+* **ovssubnet/controller/multitenant/multitenant.go**: this module watches etcd for indications of nodes added to or removed from the cluster, and updates the OVS rules to ensure each node can be reached through the VXLAN tunnel.
 

--- a/ovssubnet/api/types.go
+++ b/ovssubnet/api/types.go
@@ -10,15 +10,15 @@ const (
 type SubnetRegistry interface {
 	InitSubnets() error
 	GetSubnets() (*[]Subnet, error)
-	GetSubnet(minion string) (*Subnet, error)
-	DeleteSubnet(minion string) error
+	GetSubnet(node string) (*Subnet, error)
+	DeleteSubnet(node string) error
 	CreateSubnet(sn string, sub *Subnet) error
 	WatchSubnets(receiver chan *SubnetEvent, stop chan bool) error
 
-	InitMinions() error
-	GetMinions() (*[]string, error)
-	CreateMinion(minion string, data string) error
-	WatchMinions(receiver chan *MinionEvent, stop chan bool) error
+	InitNodes() error
+	GetNodes() (*[]string, error)
+	CreateNode(node string, data string) error
+	WatchNodes(receiver chan *NodeEvent, stop chan bool) error
 
 	WriteNetworkConfig(network string, subnetLength uint) error
 	GetContainerNetwork() (string, error)
@@ -38,18 +38,18 @@ type SubnetRegistry interface {
 }
 
 type SubnetEvent struct {
-	Type   EventType
-	Minion string
-	Sub    Subnet
+	Type EventType
+	Node string
+	Sub  Subnet
 }
 
-type MinionEvent struct {
-	Type   EventType
-	Minion string
+type NodeEvent struct {
+	Type EventType
+	Node string
 }
 
 type Subnet struct {
-	Minion string
+	NodeIP string
 	Sub    string
 }
 

--- a/ovssubnet/api/types.go
+++ b/ovssubnet/api/types.go
@@ -44,8 +44,9 @@ type SubnetEvent struct {
 }
 
 type NodeEvent struct {
-	Type EventType
-	Node string
+	Type   EventType
+	Node   string
+	NodeIP string
 }
 
 type Subnet struct {

--- a/ovssubnet/common.go
+++ b/ovssubnet/common.go
@@ -395,19 +395,15 @@ func (oc *OvsController) watchNodes() {
 					// subnet does not exist already
 					oc.AddNode(ev.Node)
 				} else {
-					// get IP of the node
-					ip, err := oc.getNodeIP(ev.Node)
-					if err != nil {
-						log.Errorf("Error calculating IP address of node %s", ev.Node)
-						continue
-					}
-					if sub.NodeIP != ip {
+					// Current node IP is obtained from event, ev.NodeIP to
+					// avoid cached/stale IP lookup by net.LookupIP()
+					if sub.NodeIP != ev.NodeIP {
 						err = oc.subnetRegistry.DeleteSubnet(ev.Node)
 						if err != nil {
 							log.Errorf("Error deleting subnet for node %s, old ip %s", ev.Node, sub.NodeIP)
 							continue
 						}
-						sub.NodeIP = ip
+						sub.NodeIP = ev.NodeIP
 						err = oc.subnetRegistry.CreateSubnet(ev.Node, sub)
 						if err != nil {
 							log.Errorf("Error creating subnet for node %s, ip %s", ev.Node, sub.NodeIP)

--- a/ovssubnet/common.go
+++ b/ovssubnet/common.go
@@ -33,8 +33,8 @@ type OvsController struct {
 
 type FlowController interface {
 	Setup(localSubnet, globalSubnet, servicesSubnet string) error
-	AddOFRules(minionIP, localSubnet, localIP string) error
-	DelOFRules(minionIP, localIP string) error
+	AddOFRules(nodeIP, localSubnet, localIP string) error
+	DelOFRules(nodeIP, localIP string) error
 	AddServiceOFRules(netID uint, IP string, protocol api.ServiceProtocol, port uint) error
 	DelServiceOFRules(netID uint, IP string, protocol api.ServiceProtocol, port uint) error
 }
@@ -100,11 +100,11 @@ func (oc *OvsController) StartMaster(sync bool, containerNetwork string, contain
 		log.Errorf("Etcd not running?")
 		return errors.New("Etcd not reachable. Sync cluster check failed.")
 	}
-	// initialize the minion key
+	// initialize the node key
 	if sync {
-		err := oc.subnetRegistry.InitMinions()
+		err := oc.subnetRegistry.InitNodes()
 		if err != nil {
-			log.Infof("Minion path already initialized.")
+			log.Infof("Node path already initialized.")
 		}
 	}
 
@@ -129,9 +129,9 @@ func (oc *OvsController) StartMaster(sync bool, containerNetwork string, contain
 	if err != nil {
 		return err
 	}
-	err = oc.ServeExistingMinions()
+	err = oc.ServeExistingNodes()
 	if err != nil {
-		log.Warningf("Error initializing existing minions: %v", err)
+		log.Warningf("Error initializing existing nodes: %v", err)
 		// no worry, we can still keep watching it.
 	}
 	if _, is_mt := oc.flowController.(*multitenant.FlowController); is_mt {
@@ -150,7 +150,7 @@ func (oc *OvsController) StartMaster(sync bool, containerNetwork string, contain
 		}
 		go oc.watchNetworks()
 	}
-	go oc.watchMinions()
+	go oc.watchNodes()
 	return nil
 }
 
@@ -187,26 +187,26 @@ func (oc *OvsController) watchNetworks() {
 				delete(oc.VnidMap, ev.Name)
 			}
 		case <-oc.sig:
-			log.Error("Signal received. Stopping watching of minions.")
+			log.Error("Signal received. Stopping watching of nodes.")
 			stop <- true
 			return
 		}
 	}
 }
 
-func (oc *OvsController) ServeExistingMinions() error {
-	minions, err := oc.subnetRegistry.GetMinions()
+func (oc *OvsController) ServeExistingNodes() error {
+	nodes, err := oc.subnetRegistry.GetNodes()
 	if err != nil {
 		return err
 	}
 
-	for _, minion := range *minions {
-		_, err := oc.subnetRegistry.GetSubnet(minion)
+	for _, node := range *nodes {
+		_, err := oc.subnetRegistry.GetSubnet(node)
 		if err == nil {
 			// subnet already exists, continue
 			continue
 		}
-		err = oc.AddNode(minion)
+		err = oc.AddNode(node)
 		if err != nil {
 			return err
 		}
@@ -217,9 +217,9 @@ func (oc *OvsController) ServeExistingMinions() error {
 func (oc *OvsController) getNodeIP(node string) (string, error) {
 	ip := net.ParseIP(node)
 	if ip == nil {
-		addrs, err := net.LookupIP(minion)
+		addrs, err := net.LookupIP(node)
 		if err != nil {
-			log.Errorf("Failed to lookup IP address for minion %s: %v", minion, err)
+			log.Errorf("Failed to lookup IP address for node %s: %v", node, err)
 			return "", err
 		}
 		for _, addr := range addrs {
@@ -235,47 +235,47 @@ func (oc *OvsController) getNodeIP(node string) (string, error) {
 	return ip.String(), nil
 }
 
-func (oc *OvsController) AddNode(minion string) error {
+func (oc *OvsController) AddNode(node string) error {
 	sn, err := oc.subnetAllocator.GetNetwork()
 	if err != nil {
-		log.Errorf("Error creating network for minion %s.", minion)
+		log.Errorf("Error creating network for node %s.", node)
 		return err
 	}
 
-	minionIP, err := oc.getMinionIP(minion)
+	nodeIP, err := oc.getNodeIP(node)
 	if err != nil {
 		return err
 	}
 
 	sub := &api.Subnet{
-		Minion: minionIP,
+		NodeIP: nodeIP,
 		Sub:    sn.String(),
 	}
-	err = oc.subnetRegistry.CreateSubnet(minion, sub)
+	err = oc.subnetRegistry.CreateSubnet(node, sub)
 	if err != nil {
-		log.Errorf("Error writing subnet to etcd for minion %s: %v", minion, sn)
+		log.Errorf("Error writing subnet to etcd for node %s: %v", node, sn)
 		return err
 	}
 	return nil
 }
 
-func (oc *OvsController) DeleteNode(minion string) error {
-	sub, err := oc.subnetRegistry.GetSubnet(minion)
+func (oc *OvsController) DeleteNode(node string) error {
+	sub, err := oc.subnetRegistry.GetSubnet(node)
 	if err != nil {
-		log.Errorf("Error fetching subnet for minion %s for delete operation.", minion)
+		log.Errorf("Error fetching subnet for node %s for delete operation.", node)
 		return err
 	}
 	_, ipnet, err := net.ParseCIDR(sub.Sub)
 	if err != nil {
-		log.Errorf("Error parsing subnet for minion %s for deletion: %s", minion, sub.Sub)
+		log.Errorf("Error parsing subnet for node %s for deletion: %s", node, sub.Sub)
 		return err
 	}
 	oc.subnetAllocator.ReleaseNetwork(ipnet)
-	return oc.subnetRegistry.DeleteSubnet(minion)
+	return oc.subnetRegistry.DeleteSubnet(node)
 }
 
 func (oc *OvsController) syncWithMaster() error {
-	return oc.subnetRegistry.CreateMinion(oc.hostName, oc.localIP)
+	return oc.subnetRegistry.CreateNode(oc.hostName, oc.localIP)
 }
 
 func (oc *OvsController) StartNode(sync, skipsetup bool) error {
@@ -315,7 +315,7 @@ func (oc *OvsController) StartNode(sync, skipsetup bool) error {
 		log.Errorf("Could not fetch existing subnets: %v", err)
 	}
 	for _, s := range *subnets {
-		oc.flowController.AddOFRules(s.Minion, s.Sub, oc.localIP)
+		oc.flowController.AddOFRules(s.NodeIP, s.Sub, oc.localIP)
 	}
 	if _, ok := oc.flowController.(*multitenant.FlowController); ok {
 		nslist, err := oc.subnetRegistry.GetNetNamespaces()
@@ -371,7 +371,7 @@ func (oc *OvsController) initSelfSubnet() error {
 	for {
 		sub, err := oc.subnetRegistry.GetSubnet(oc.hostName)
 		if err != nil {
-			log.Errorf("Could not find an allocated subnet for minion %s: %s. Waiting...", oc.hostName, err)
+			log.Errorf("Could not find an allocated subnet for node %s: %s. Waiting...", oc.hostName, err)
 			time.Sleep(2 * time.Second)
 			continue
 		}
@@ -380,46 +380,46 @@ func (oc *OvsController) initSelfSubnet() error {
 	}
 }
 
-func (oc *OvsController) watchMinions() {
+func (oc *OvsController) watchNodes() {
 	// watch latest?
 	stop := make(chan bool)
-	minevent := make(chan *api.MinionEvent)
-	go oc.subnetRegistry.WatchMinions(minevent, stop)
+	nodeEvent := make(chan *api.NodeEvent)
+	go oc.subnetRegistry.WatchNodes(nodeEvent, stop)
 	for {
 		select {
-		case ev := <-minevent:
+		case ev := <-nodeEvent:
 			switch ev.Type {
 			case api.Added:
-				sub, err := oc.subnetRegistry.GetSubnet(ev.Minion)
+				sub, err := oc.subnetRegistry.GetSubnet(ev.Node)
 				if err != nil {
 					// subnet does not exist already
-					oc.AddNode(ev.Minion)
+					oc.AddNode(ev.Node)
 				} else {
-					// get IP of the minion
-					ip, err := oc.getMinionIP(ev.Minion)
+					// get IP of the node
+					ip, err := oc.getNodeIP(ev.Node)
 					if err != nil {
-						log.Errorf("Error calculating IP address of node %s", ev.Minion)
+						log.Errorf("Error calculating IP address of node %s", ev.Node)
 						continue
 					}
-					if sub.Minion != ip {
-						err = oc.subnetRegistry.DeleteSubnet(ev.Minion)
+					if sub.NodeIP != ip {
+						err = oc.subnetRegistry.DeleteSubnet(ev.Node)
 						if err != nil {
-							log.Errorf("Error deleting subnet for node %s, old ip %s", ev.Minion, sub.Minion)
+							log.Errorf("Error deleting subnet for node %s, old ip %s", ev.Node, sub.NodeIP)
 							continue
 						}
-						sub.Minion = ip
-						err = oc.subnetRegistry.CreateSubnet(ev.Minion, sub)
+						sub.NodeIP = ip
+						err = oc.subnetRegistry.CreateSubnet(ev.Node, sub)
 						if err != nil {
-							log.Errorf("Error creating subnet for node %s, ip %s", ev.Minion, sub.Minion)
+							log.Errorf("Error creating subnet for node %s, ip %s", ev.Node, sub.NodeIP)
 							continue
 						}
 					}
 				}
 			case api.Deleted:
-				oc.DeleteNode(ev.Minion)
+				oc.DeleteNode(ev.Node)
 			}
 		case <-oc.sig:
-			log.Error("Signal received. Stopping watching of minions.")
+			log.Error("Signal received. Stopping watching of nodes.")
 			stop <- true
 			return
 		}
@@ -458,10 +458,10 @@ func (oc *OvsController) watchCluster() {
 			switch ev.Type {
 			case api.Added:
 				// add openflow rules
-				oc.flowController.AddOFRules(ev.Sub.Minion, ev.Sub.Sub, oc.localIP)
+				oc.flowController.AddOFRules(ev.Sub.NodeIP, ev.Sub.Sub, oc.localIP)
 			case api.Deleted:
-				// delete openflow rules meant for the minion
-				oc.flowController.DelOFRules(ev.Sub.Minion, oc.localIP)
+				// delete openflow rules meant for the node
+				oc.flowController.DelOFRules(ev.Sub.NodeIP, oc.localIP)
 			}
 		case <-oc.sig:
 			stop <- true

--- a/ovssubnet/controller/kube/kube.go
+++ b/ovssubnet/controller/kube/kube.go
@@ -72,9 +72,9 @@ func (c *FlowController) manageLocalIpam(ipnet *net.IPNet) error {
 	return nil
 }
 
-func (c *FlowController) AddOFRules(minionIP, subnet, localIP string) error {
-	cookie := generateCookie(minionIP)
-	if minionIP == localIP {
+func (c *FlowController) AddOFRules(nodeIP, subnet, localIP string) error {
+	cookie := generateCookie(nodeIP)
+	if nodeIP == localIP {
 		// self, so add the input rules for containers that are not processed through kube-hooks
 		// for the input rules to pods, see the kube-hook
 		iprule := fmt.Sprintf("table=0,cookie=0x%s,priority=75,ip,nw_dst=%s,actions=output:9", cookie, subnet)
@@ -85,8 +85,8 @@ func (c *FlowController) AddOFRules(minionIP, subnet, localIP string) error {
 		log.Infof("Output of adding %s: %s (%v)", arprule, o, e)
 		return e
 	} else {
-		iprule := fmt.Sprintf("table=0,cookie=0x%s,priority=100,ip,nw_dst=%s,actions=set_field:%s->tun_dst,output:1", cookie, subnet, minionIP)
-		arprule := fmt.Sprintf("table=0,cookie=0x%s,priority=100,arp,nw_dst=%s,actions=set_field:%s->tun_dst,output:1", cookie, subnet, minionIP)
+		iprule := fmt.Sprintf("table=0,cookie=0x%s,priority=100,ip,nw_dst=%s,actions=set_field:%s->tun_dst,output:1", cookie, subnet, nodeIP)
+		arprule := fmt.Sprintf("table=0,cookie=0x%s,priority=100,arp,nw_dst=%s,actions=set_field:%s->tun_dst,output:1", cookie, subnet, nodeIP)
 		o, e := exec.Command("ovs-ofctl", "-O", "OpenFlow13", "add-flow", "br0", iprule).CombinedOutput()
 		log.Infof("Output of adding %s: %s (%v)", iprule, o, e)
 		o, e = exec.Command("ovs-ofctl", "-O", "OpenFlow13", "add-flow", "br0", arprule).CombinedOutput()
@@ -96,10 +96,10 @@ func (c *FlowController) AddOFRules(minionIP, subnet, localIP string) error {
 	return nil
 }
 
-func (c *FlowController) DelOFRules(minion, localIP string) error {
-	log.Infof("Calling del rules for %s", minion)
-	cookie := generateCookie(minion)
-	if minion == localIP {
+func (c *FlowController) DelOFRules(node, localIP string) error {
+	log.Infof("Calling del rules for %s", node)
+	cookie := generateCookie(node)
+	if node == localIP {
 		iprule := fmt.Sprintf("table=0,cookie=0x%s/0xffffffff,ip,in_port=10", cookie)
 		arprule := fmt.Sprintf("table=0,cookie=0x%s/0xffffffff,arp,in_port=10", cookie)
 		o, e := exec.Command("ovs-ofctl", "-O", "OpenFlow13", "del-flows", "br0", iprule).CombinedOutput()

--- a/ovssubnet/controller/multitenant/multitenant.go
+++ b/ovssubnet/controller/multitenant/multitenant.go
@@ -41,14 +41,14 @@ func (c *FlowController) Setup(localSubnet, containerNetwork, servicesNetwork st
 	return err
 }
 
-func (c *FlowController) AddOFRules(minionIP, subnet, localIP string) error {
-	if minionIP == localIP {
+func (c *FlowController) AddOFRules(nodeIP, subnet, localIP string) error {
+	if nodeIP == localIP {
 		return nil
 	}
 
-	cookie := generateCookie(minionIP)
-	iprule := fmt.Sprintf("table=7,cookie=0x%s,priority=100,ip,nw_dst=%s,actions=move:NXM_NX_REG0[]->NXM_NX_TUN_ID[0..31],set_field:%s->tun_dst,output:1", cookie, subnet, minionIP)
-	arprule := fmt.Sprintf("table=8,cookie=0x%s,priority=100,arp,nw_dst=%s,actions=move:NXM_NX_REG0[]->NXM_NX_TUN_ID[0..31],set_field:%s->tun_dst,output:1", cookie, subnet, minionIP)
+	cookie := generateCookie(nodeIP)
+	iprule := fmt.Sprintf("table=7,cookie=0x%s,priority=100,ip,nw_dst=%s,actions=move:NXM_NX_REG0[]->NXM_NX_TUN_ID[0..31],set_field:%s->tun_dst,output:1", cookie, subnet, nodeIP)
+	arprule := fmt.Sprintf("table=8,cookie=0x%s,priority=100,arp,nw_dst=%s,actions=move:NXM_NX_REG0[]->NXM_NX_TUN_ID[0..31],set_field:%s->tun_dst,output:1", cookie, subnet, nodeIP)
 	o, e := exec.Command("ovs-ofctl", "-O", "OpenFlow13", "add-flow", "br0", iprule).CombinedOutput()
 	log.Infof("Output of adding %s: %s (%v)", iprule, o, e)
 	o, e = exec.Command("ovs-ofctl", "-O", "OpenFlow13", "add-flow", "br0", arprule).CombinedOutput()
@@ -56,13 +56,13 @@ func (c *FlowController) AddOFRules(minionIP, subnet, localIP string) error {
 	return e
 }
 
-func (c *FlowController) DelOFRules(minion, localIP string) error {
-	if minion == localIP {
+func (c *FlowController) DelOFRules(node, localIP string) error {
+	if node == localIP {
 		return nil
 	}
 
-	log.Infof("Calling del rules for %s", minion)
-	cookie := generateCookie(minion)
+	log.Infof("Calling del rules for %s", node)
+	cookie := generateCookie(node)
 	iprule := fmt.Sprintf("table=7,cookie=0x%s/0xffffffff", cookie)
 	arprule := fmt.Sprintf("table=8,cookie=0x%s/0xffffffff", cookie)
 	o, e := exec.Command("ovs-ofctl", "-O", "OpenFlow13", "del-flows", "br0", iprule).CombinedOutput()

--- a/ovssubnet/registry/registry.go
+++ b/ovssubnet/registry/registry.go
@@ -41,6 +41,18 @@ func newNodeEvent(action, key, value string) *api.NodeEvent {
 
 	if key != "" {
 		_, nodeEvent.Node = path.Split(key)
+
+		/* TODO(ravips): FIXME
+		var node kapi.Node
+		err := json.Unmarshal([]byte(value), &node)
+		if err != nil {
+			fmt.Printf("Error decoding node event: nil key (%s,%s,%s).\n", action, key, value)
+			return nil
+		}
+		if len(node.Status.Addresses) > 0 {
+			nodeEvent.NodeIP = node.Status.Addresses[0].Address
+		}
+		*/
 		return nodeEvent
 	}
 

--- a/ovssubnet/registry/registry.go
+++ b/ovssubnet/registry/registry.go
@@ -21,7 +21,7 @@ type EtcdConfig struct {
 	CAFile           string
 	SubnetPath       string
 	SubnetConfigPath string
-	MinionPath       string
+	NodePath         string
 }
 
 type EtcdSubnetRegistry struct {
@@ -30,27 +30,27 @@ type EtcdSubnetRegistry struct {
 	etcdCfg *EtcdConfig
 }
 
-func newMinionEvent(action, key, value string) *api.MinionEvent {
-	min := &api.MinionEvent{}
+func newNodeEvent(action, key, value string) *api.NodeEvent {
+	nodeEvent := &api.NodeEvent{}
 	switch action {
 	case "delete", "deleted", "expired":
-		min.Type = api.Deleted
+		nodeEvent.Type = api.Deleted
 	default:
-		min.Type = api.Added
+		nodeEvent.Type = api.Added
 	}
 
 	if key != "" {
-		_, min.Minion = path.Split(key)
-		return min
+		_, nodeEvent.Node = path.Split(key)
+		return nodeEvent
 	}
 
-	fmt.Printf("Error decoding minion event: nil key (%s,%s,%s).\n", action, key, value)
+	fmt.Printf("Error decoding node event: nil key (%s,%s,%s).\n", action, key, value)
 	return nil
 }
 
 func newSubnetEvent(resp *etcd.Response) *api.SubnetEvent {
 	var value string
-	_, minkey := path.Split(resp.Node.Key)
+	_, nodeKey := path.Split(resp.Node.Key)
 	var t api.EventType
 	switch resp.Action {
 	case "deleted", "delete", "expired":
@@ -63,9 +63,9 @@ func newSubnetEvent(resp *etcd.Response) *api.SubnetEvent {
 	var sub api.Subnet
 	if err := json.Unmarshal([]byte(value), &sub); err == nil {
 		return &api.SubnetEvent{
-			Type:   t,
-			Minion: minkey,
-			Sub:    sub,
+			Type: t,
+			Node: nodeKey,
+			Sub:  sub,
 		}
 	}
 	log.Errorf("Failed to unmarshal response: %v", resp)
@@ -121,34 +121,34 @@ func (sub *EtcdSubnetRegistry) InitSubnets() error {
 	return err
 }
 
-func (sub *EtcdSubnetRegistry) InitMinions() error {
-	key := sub.etcdCfg.MinionPath
+func (sub *EtcdSubnetRegistry) InitNodes() error {
+	key := sub.etcdCfg.NodePath
 	_, err := sub.client().SetDir(key, 0)
 	return err
 }
 
-func (sub *EtcdSubnetRegistry) GetMinions() (*[]string, error) {
-	key := sub.etcdCfg.MinionPath
+func (sub *EtcdSubnetRegistry) GetNodes() (*[]string, error) {
+	key := sub.etcdCfg.NodePath
 	resp, err := sub.client().Get(key, false, true)
 	if err != nil {
 		return nil, err
 	}
 
 	if resp.Node.Dir == false {
-		return nil, errors.New("Minion path is not a directory")
+		return nil, errors.New("Node path is not a directory")
 	}
 
-	minions := make([]string, 0)
+	nodes := make([]string, 0)
 
 	for _, node := range resp.Node.Nodes {
 		if node.Key == "" {
-			log.Errorf("Error unmarshalling GetMinions response node %s", node.Key)
+			log.Errorf("Error unmarshalling GetNodes response node %s", node.Key)
 			continue
 		}
-		_, minion := path.Split(node.Key)
-		minions = append(minions, minion)
+		_, node := path.Split(node.Key)
+		nodes = append(nodes, node)
 	}
-	return &minions, nil
+	return &nodes, nil
 }
 
 func (sub *EtcdSubnetRegistry) InitServices() error {
@@ -184,8 +184,8 @@ func (sub *EtcdSubnetRegistry) GetSubnets() (*[]api.Subnet, error) {
 	return &subnets, err
 }
 
-func (sub *EtcdSubnetRegistry) GetSubnet(minionip string) (*api.Subnet, error) {
-	key := path.Join(sub.etcdCfg.SubnetPath, minionip)
+func (sub *EtcdSubnetRegistry) GetSubnet(nodeip string) (*api.Subnet, error) {
+	key := path.Join(sub.etcdCfg.SubnetPath, nodeip)
 	resp, err := sub.client().Get(key, false, false)
 	if err == nil {
 		log.Infof("Unmarshalling response: %s", resp.Node.Value)
@@ -198,8 +198,8 @@ func (sub *EtcdSubnetRegistry) GetSubnet(minionip string) (*api.Subnet, error) {
 	return nil, err
 }
 
-func (sub *EtcdSubnetRegistry) DeleteSubnet(minion string) error {
-	key := path.Join(sub.etcdCfg.SubnetPath, minion)
+func (sub *EtcdSubnetRegistry) DeleteSubnet(node string) error {
+	key := path.Join(sub.etcdCfg.SubnetPath, node)
 	_, err := sub.client().Delete(key, false)
 	return err
 }
@@ -252,8 +252,8 @@ func (sub *EtcdSubnetRegistry) GetSubnetLength() (uint64, error) {
 	return 0, err
 }
 
-func (sub *EtcdSubnetRegistry) CreateMinion(minion string, data string) error {
-	key := path.Join(sub.etcdCfg.MinionPath, minion)
+func (sub *EtcdSubnetRegistry) CreateNode(node string, data string) error {
+	key := path.Join(sub.etcdCfg.NodePath, node)
 	_, err := sub.client().Get(key, false, false)
 	if err != nil {
 		// good, it does not exist, write it
@@ -267,11 +267,11 @@ func (sub *EtcdSubnetRegistry) CreateMinion(minion string, data string) error {
 	return nil
 }
 
-func (sub *EtcdSubnetRegistry) CreateSubnet(minion string, subnet *api.Subnet) error {
+func (sub *EtcdSubnetRegistry) CreateSubnet(node string, subnet *api.Subnet) error {
 	subbytes, _ := json.Marshal(subnet)
 	data := string(subbytes)
-	log.Infof("Minion subnet structure: %s", data)
-	key := path.Join(sub.etcdCfg.SubnetPath, minion)
+	log.Infof("Node subnet structure: %s", data)
+	key := path.Join(sub.etcdCfg.SubnetPath, node)
 	_, err := sub.client().Create(key, data, 0)
 	if err != nil {
 		_, err = sub.client().Update(key, data, 0)
@@ -284,11 +284,11 @@ func (sub *EtcdSubnetRegistry) CreateSubnet(minion string, subnet *api.Subnet) e
 	return nil
 }
 
-func (sub *EtcdSubnetRegistry) WatchMinions(receiver chan *api.MinionEvent, stop chan bool) error {
+func (sub *EtcdSubnetRegistry) WatchNodes(receiver chan *api.NodeEvent, stop chan bool) error {
 	var rev uint64
 	rev = 0
-	key := sub.etcdCfg.MinionPath
-	log.Infof("Watching %s for new minions.", key)
+	key := sub.etcdCfg.NodePath
+	log.Infof("Watching %s for new nodes.", key)
 	for {
 		resp, err := sub.watch(key, rev, stop)
 		if err != nil && err == etcd.ErrWatchStoppedByUser {
@@ -299,9 +299,9 @@ func (sub *EtcdSubnetRegistry) WatchMinions(receiver chan *api.MinionEvent, stop
 			continue
 		}
 		rev = resp.Node.ModifiedIndex + 1
-		log.Infof("Issuing a minion event: %v", resp)
-		minevent := newMinionEvent(resp.Action, resp.Node.Key, resp.Node.Value)
-		receiver <- minevent
+		log.Infof("Issuing a node event: %v", resp)
+		nodeEvent := newNodeEvent(resp.Action, resp.Node.Key, resp.Node.Value)
+		receiver <- nodeEvent
 	}
 }
 

--- a/ovssubnet/registry/registry.go
+++ b/ovssubnet/registry/registry.go
@@ -42,18 +42,21 @@ func newNodeEvent(action, key, value string) *api.NodeEvent {
 	if key != "" {
 		_, nodeEvent.Node = path.Split(key)
 
-		/* TODO(ravips): FIXME
-		var node kapi.Node
+		var node map[string]interface{}
 		err := json.Unmarshal([]byte(value), &node)
-		if err != nil {
-			fmt.Printf("Error decoding node event: nil key (%s,%s,%s).\n", action, key, value)
-			return nil
+		if err == nil {
+			nodeStatus, ok := node["Status"].(map[string]interface{})
+			if ok {
+				nodeAddresses, ok := nodeStatus["Addresses"].([]interface{})
+				if ok {
+					nodeAddressMap, ok := nodeAddresses[0].(map[string]interface{})
+					if ok {
+						nodeEvent.NodeIP = nodeAddressMap["Address"].(string)
+						return nodeEvent
+					}
+				}
+			}
 		}
-		if len(node.Status.Addresses) > 0 {
-			nodeEvent.NodeIP = node.Status.Addresses[0].Address
-		}
-		*/
-		return nodeEvent
 	}
 
 	fmt.Printf("Error decoding node event: nil key (%s,%s,%s).\n", action, key, value)

--- a/rel-eng/openshift-sdn-master.sysconfig
+++ b/rel-eng/openshift-sdn-master.sysconfig
@@ -20,12 +20,12 @@
 #  -log_dir="": If non-empty, write log files in this directory
 #  -logtostderr=false: log to standard error instead of files
 #  -master=true: Run in master mode
-#  -minion=false: Run in minion mode
+#  -node=false: Run in node mode
 #  -public-ip="": Publicly reachable IP address of this host (for node
 #   mode).
-#  -skip-setup=false: Skip the setup when in minion mode
+#  -skip-setup=false: Skip the setup when in node mode
 #  -stderrthreshold=0: logs at or above this threshold go to stderr
-#  -sync=false: Sync the minions directly to etcd-path (Do not wait
+#  -sync=false: Sync the nodes directly to etcd-path (Do not wait
 #    for PaaS to do so!)
 #  -v=0: log level for V logs
 #  -vmodule=: comma-separated list of pattern=N settings for

--- a/rel-eng/openshift-sdn-node.service
+++ b/rel-eng/openshift-sdn-node.service
@@ -11,7 +11,7 @@ Documentation=https://github.com/openshift/origin
 [Service]
 Type=simple
 EnvironmentFile=-/etc/sysconfig/openshift-sdn-node
-ExecStart=/usr/bin/openshift-sdn -minion -etcd-endpoints=${MASTER_URL} -public-ip=${MINION_IP} $OPTIONS
+ExecStart=/usr/bin/openshift-sdn -node -etcd-endpoints=${MASTER_URL} -public-ip=${NODE_IP} $OPTIONS
 Restart=on-failure
 RestartSec=1s
 SyslogIdentifier=openshift-sdn-node

--- a/rel-eng/openshift-sdn-node.sysconfig
+++ b/rel-eng/openshift-sdn-node.sysconfig
@@ -18,12 +18,12 @@
 #  -log_dir="": If non-empty, write log files in this directory
 #  -logtostderr=false: log to standard error instead of files
 #  -master=true: Run in master mode
-#  -minion=false: Run in minion mode
+#  -node=false: Run in node mode
 #  -public-ip="": Publicly reachable IP address of this host (for node
 #   mode).
-#  -skip-setup=false: Skip the setup when in minion mode
+#  -skip-setup=false: Skip the setup when in node mode
 #  -stderrthreshold=0: logs at or above this threshold go to stderr
-#  -sync=false: Sync the minions directly to etcd-path (Do not wait
+#  -sync=false: Sync the nodes directly to etcd-path (Do not wait
 #    for PaaS to do so!)
 #  -v=0: log level for V logs
 #  -vmodule=: comma-separated list of pattern=N settings for
@@ -39,11 +39,11 @@
 MASTER_URL=
 
 # The externally-facing IP for this node must be specified in the
-# MINION_IP variable.
+# NODE_IP variable.
 #
 # Example:
-#   MINION_IP=10.0.0.20
-MINION_IP=
+#   NODE_IP=10.0.0.20
+NODE_IP=
 
 # Any additional options can be specified here, in the OPTIONS
 # variable.


### PR DESCRIPTION
-  Replace 'minion' with 'node' or 'nodeIP' based on context
-  Pass updated node IP in the NodeEvent to avoid cache/stale lookup by net.LookupIP()
-  In openshift-sdn standalone mode, trigger node event when node ip changes