### PR TITLE
Fix veth lookup for kernels with interface suffixes

### DIFF
--- a/ovssubnet/controller/kube/bin/openshift-ovs-subnet
+++ b/ovssubnet/controller/kube/bin/openshift-ovs-subnet
@@ -15,6 +15,17 @@ lockwrap() {
     ) 200>${lock_file}
 }
 
+# Retrieve the name of the host-local member of the veth pair that
+# connects the container (identified by pid) to the docker bridge.
+get_veth_host() {
+    local pid=$1
+
+    local veth_ifindex=$(nsenter -n -t $pid -- ethtool -S eth0 | sed -n -e 's/.*peer_ifindex: //p')
+    # Strip a suffix starting with '@' from the interface name.
+    # The suffixed interface name won't be recognized by brctl or ovs-*
+    ip link show | sed -ne "s/^$veth_ifindex: \([^:@]*\).*/\1/p"
+}
+
 Init() {
     true
 }
@@ -34,8 +45,7 @@ Setup() {
     new_ip=$ipaddr
     ipaddr_sub=$(docker inspect --format "{{.NetworkSettings.IPPrefixLen}}" ${net_container})
     docker_gateway=$(docker inspect --format "{{.NetworkSettings.Gateway}}" ${net_container})
-    veth_ifindex=$(nsenter -n -t $pid -- ethtool -S eth0 | sed -n -e 's/.*peer_ifindex: //p')
-    veth_host=$(ip link show | sed -ne "s/^$veth_ifindex: \([^:]*\).*/\1/p")
+    veth_host=$(get_veth_host $pid)
 
     brctl delif lbr0 $veth_host
     ovs-vsctl add-port br0 ${veth_host} 
@@ -58,8 +68,7 @@ Teardown() {
       # quit, nothing for the SDN here
       exit 0
     fi
-    veth_ifindex=$(nsenter -n -t $pid -- ethtool -S eth0 | sed -n -e 's/.*peer_ifindex: //p')
-    veth_host=$(ip link show | sed -ne "s/^$veth_ifindex: \([^:]*\).*/\1/p")
+    veth_host=$(get_veth_host $pid)
     ovs_port=$(ovs-ofctl -O OpenFlow13 dump-ports-desc br0  | grep ${veth_host} | cut -d "(" -f 1 | tr -d ' ')
     ovs-vsctl del-port $veth_host
     ovs-ofctl -O OpenFlow13 del-flows br0 "table=0,cookie=0x${ovs_port}/0xffffffff"


### PR DESCRIPTION
openshift-ovs-subnet fails on Fedora 22 due to 'ip link show' displaying
interface names with a suffix starting with '@', e.g.

  24: vetha06b051@if23: ...

Invoking brctl or ovs-* with the interface 'vetha06b051@if23' fails, and
it is necessary to use the name without the suffix (e.g. 'vetha06b051').