### PR TITLE
Multi-tenant service isolation (again!)

### DIFF
--- a/main.go
+++ b/main.go
@@ -17,7 +17,7 @@ import (
 )
 
 type NetworkManager interface {
-	StartMaster(sync bool, containerNetwork string, containerSubnetLength uint) error
+	StartMaster(sync bool, containerNetwork string, containerSubnetLength uint, serviceNetwork string) error
 	StartNode(sync, skipsetup bool) error
 	Stop()
 }
@@ -25,6 +25,7 @@ type NetworkManager interface {
 type CmdLineOpts struct {
 	containerNetwork      string
 	containerSubnetLength uint
+	serviceNetwork        string
 	etcdEndpoints         string
 	etcdPath              string
 	etcdKeyfile           string
@@ -49,6 +50,7 @@ var opts CmdLineOpts
 func init() {
 	flag.StringVar(&opts.containerNetwork, "container-network", "10.1.0.0/16", "container network")
 	flag.UintVar(&opts.containerSubnetLength, "container-subnet-length", 8, "container subnet length")
+	flag.StringVar(&opts.serviceNetwork, "service-network", "172.30.0.0/16", "service network")
 	flag.StringVar(&opts.etcdEndpoints, "etcd-endpoints", "http://127.0.0.1:4001", "a comma-delimited list of etcd endpoints")
 	flag.StringVar(&opts.etcdPath, "etcd-path", "/registry/sdn/", "etcd path")
 	flag.StringVar(&opts.nodePath, "node-path", "/kubernetes.io/minions/", "etcd path that will be watched for node creation/deletion (Note: -sync flag will override this path with -etcd-path)")
@@ -158,7 +160,7 @@ func main() {
 			log.Fatalf("Failed to start openshift sdn in node mode: %v", err)
 		}
 	} else if opts.master {
-		err := be.StartMaster(opts.sync, opts.containerNetwork, opts.containerSubnetLength)
+		err := be.StartMaster(opts.sync, opts.containerNetwork, opts.containerSubnetLength, opts.serviceNetwork)
 		if err != nil {
 			log.Fatalf("Failed to start openshift sdn in master mode: %v", err)
 		}

--- a/ovssubnet/api/types.go
+++ b/ovssubnet/api/types.go
@@ -20,7 +20,7 @@ type SubnetRegistry interface {
 	CreateNode(nodeName string, data string) error
 	WatchNodes(receiver chan *NodeEvent, stop chan bool) error
 
-	WriteNetworkConfig(network string, subnetLength uint) error
+	WriteNetworkConfig(network string, subnetLength uint, serviceNetwork string) error
 	GetContainerNetwork() (string, error)
 	GetSubnetLength() (uint64, error)
 	CheckEtcdIsAlive(seconds uint64) bool
@@ -31,6 +31,10 @@ type SubnetRegistry interface {
 	GetNetNamespace(name string) (NetNamespace, error)
 	WriteNetNamespace(name string, id uint) error
 	DeleteNetNamespace(name string) error
+
+	GetServicesNetwork() (string, error)
+	GetServices() (*[]Service, error)
+	WatchServices(receiver chan *ServiceEvent, stop chan bool) error
 }
 
 type SubnetEvent struct {
@@ -64,4 +68,24 @@ type NetNamespaceEvent struct {
 type NamespaceEvent struct {
 	Type EventType
 	Name string
+}
+
+type ServiceProtocol string
+
+const (
+	TCP ServiceProtocol = "TCP"
+	UDP ServiceProtocol = "UDP"
+)
+
+type Service struct {
+	Name      string
+	Namespace string
+	IP        string
+	Protocol  ServiceProtocol
+	Port      uint
+}
+
+type ServiceEvent struct {
+	Type    EventType
+	Service Service
 }

--- a/ovssubnet/common.go
+++ b/ovssubnet/common.go
@@ -33,9 +33,11 @@ type OvsController struct {
 }
 
 type FlowController interface {
-	Setup(localSubnetIP, globalSubnetIP string) error
+	Setup(localSubnetIP, globalSubnetIP, serviceSubnetIP string) error
 	AddOFRules(nodeIP, localSubnetIP, localIP string) error
 	DelOFRules(nodeIP, localIP string) error
+	AddServiceOFRules(netID uint, IP string, protocol api.ServiceProtocol, port uint) error
+	DelServiceOFRules(netID uint, IP string, protocol api.ServiceProtocol, port uint) error
 }
 
 func NewKubeController(sub api.SubnetRegistry, hostname string, selfIP string, ready chan struct{}) (*OvsController, error) {
@@ -92,7 +94,7 @@ func NewController(sub api.SubnetRegistry, hostname string, selfIP string, ready
 	}, nil
 }
 
-func (oc *OvsController) StartMaster(sync bool, containerNetwork string, containerSubnetLength uint) error {
+func (oc *OvsController) StartMaster(sync bool, containerNetwork string, containerSubnetLength uint, serviceNetwork string) error {
 	// wait a minute for etcd to come alive
 	status := oc.subnetRegistry.CheckEtcdIsAlive(60)
 	if !status {
@@ -119,7 +121,7 @@ func (oc *OvsController) StartMaster(sync bool, containerNetwork string, contain
 		subrange = append(subrange, sub.SubnetIP)
 	}
 
-	err = oc.subnetRegistry.WriteNetworkConfig(containerNetwork, containerSubnetLength)
+	err = oc.subnetRegistry.WriteNetworkConfig(containerNetwork, containerSubnetLength, serviceNetwork)
 	if err != nil {
 		return err
 	}
@@ -312,7 +314,12 @@ func (oc *OvsController) StartNode(sync, skipsetup bool) error {
 			log.Errorf("Failed to obtain ContainerNetwork: %v", err)
 			return err
 		}
-		err = oc.flowController.Setup(oc.localSubnet.SubnetIP, containerNetwork)
+		servicesNetwork, err := oc.subnetRegistry.GetServicesNetwork()
+		if err != nil {
+			log.Errorf("Failed to obtain ServicesNetwork: %v", err)
+			return err
+		}
+		err = oc.flowController.Setup(oc.localSubnet.SubnetIP, containerNetwork, servicesNetwork)
 		if err != nil {
 			return err
 		}
@@ -333,6 +340,15 @@ func (oc *OvsController) StartNode(sync, skipsetup bool) error {
 			oc.VNIDMap[ns.Name] = ns.NetID
 		}
 		go oc.watchVnids()
+
+		services, err := oc.subnetRegistry.GetServices()
+		if err != nil {
+			return err
+		}
+		for _, svc := range *services {
+			oc.flowController.AddServiceOFRules(oc.VNIDMap[svc.Namespace], svc.IP, svc.Protocol, svc.Port)
+		}
+		go oc.watchServices()
 	}
 	go oc.watchCluster()
 
@@ -414,6 +430,28 @@ func (oc *OvsController) watchNodes() {
 			}
 		case <-oc.sig:
 			log.Error("Signal received. Stopping watching of nodes.")
+			stop <- true
+			return
+		}
+	}
+}
+
+func (oc *OvsController) watchServices() {
+	stop := make(chan bool)
+	svcevent := make(chan *api.ServiceEvent)
+	go oc.subnetRegistry.WatchServices(svcevent, stop)
+	for {
+		select {
+		case ev := <-svcevent:
+			netid := oc.VNIDMap[ev.Service.Namespace]
+			switch ev.Type {
+			case api.Added:
+				oc.flowController.AddServiceOFRules(netid, ev.Service.IP, ev.Service.Protocol, ev.Service.Port)
+			case api.Deleted:
+				oc.flowController.DelServiceOFRules(netid, ev.Service.IP, ev.Service.Protocol, ev.Service.Port)
+			}
+		case <-oc.sig:
+			log.Error("Signal received. Stopping watching of services.")
 			stop <- true
 			return
 		}

--- a/ovssubnet/controller/kube/kube.go
+++ b/ovssubnet/controller/kube/kube.go
@@ -10,6 +10,7 @@ import (
 	"strconv"
 	"syscall"
 
+	"github.com/openshift/openshift-sdn/ovssubnet/api"
 	"github.com/openshift/openshift-sdn/pkg/netutils"
 	netutils_server "github.com/openshift/openshift-sdn/pkg/netutils/server"
 )
@@ -21,7 +22,7 @@ func NewFlowController() *FlowController {
 	return &FlowController{}
 }
 
-func (c *FlowController) Setup(localSubnet, containerNetwork string) error {
+func (c *FlowController) Setup(localSubnet, containerNetwork, servicesNetwork string) error {
 	_, ipnet, err := net.ParseCIDR(localSubnet)
 	subnetMaskLength, _ := ipnet.Mask.Size()
 	gateway := netutils.GenerateDefaultGateway(ipnet).String()
@@ -120,4 +121,12 @@ func (c *FlowController) DelOFRules(node, localIP string) error {
 
 func generateCookie(ip string) string {
 	return hex.EncodeToString(net.ParseIP(ip).To4())
+}
+
+func (c *FlowController) AddServiceOFRules(netID uint, IP string, protocol api.ServiceProtocol, port uint) error {
+	return nil
+}
+
+func (c *FlowController) DelServiceOFRules(netID uint, IP string, protocol api.ServiceProtocol, port uint) error {
+	return nil
 }

--- a/ovssubnet/controller/lbr/lbr.go
+++ b/ovssubnet/controller/lbr/lbr.go
@@ -8,6 +8,7 @@ import (
 	"os/exec"
 	"strconv"
 
+	"github.com/openshift/openshift-sdn/ovssubnet/api"
 	"github.com/openshift/openshift-sdn/pkg/netutils"
 )
 
@@ -18,7 +19,7 @@ func NewFlowController() *FlowController {
 	return &FlowController{}
 }
 
-func (c *FlowController) Setup(localSubnet, containerNetwork string) error {
+func (c *FlowController) Setup(localSubnet, containerNetwork, servicesNetwork string) error {
 	_, ipnet, err := net.ParseCIDR(localSubnet)
 	subnetMaskLength, _ := ipnet.Mask.Size()
 	out, err := exec.Command("openshift-sdn-simple-setup-node.sh", netutils.GenerateDefaultGateway(ipnet).String(), ipnet.String(), containerNetwork, strconv.Itoa(subnetMaskLength)).CombinedOutput()
@@ -78,4 +79,12 @@ func (c *FlowController) DelOFRules(node, localIP string) error {
 
 func generateCookie(ip string) string {
 	return hex.EncodeToString(net.ParseIP(ip).To4())
+}
+
+func (c *FlowController) AddServiceOFRules(netID uint, IP string, protocol api.ServiceProtocol, port uint) error {
+	return nil
+}
+
+func (c *FlowController) DelServiceOFRules(netID uint, IP string, protocol api.ServiceProtocol, port uint) error {
+	return nil
 }

--- a/ovssubnet/controller/multitenant/bin/openshift-ovs-multitenant
+++ b/ovssubnet/controller/multitenant/bin/openshift-ovs-multitenant
@@ -57,9 +57,9 @@ Setup() {
 
     ovs-ofctl -O OpenFlow13 add-flow br0 "table=3,cookie=0x${ovs_port},priority=100,in_port=${ovs_port},ip,nw_src=${ipaddr},actions=load:${tenant_id}->NXM_NX_REG0[],goto_table:4"
     if [ "${tenant_id}" == "0" ]; then
-      ovs-ofctl -O OpenFlow13 add-flow br0 "table=5,cookie=0x${ovs_port},priority=150,ip,nw_dst=${ipaddr},actions=output:${ovs_port}"
+      ovs-ofctl -O OpenFlow13 add-flow br0 "table=6,cookie=0x${ovs_port},priority=150,ip,nw_dst=${ipaddr},actions=output:${ovs_port}"
     else
-      ovs-ofctl -O OpenFlow13 add-flow br0 "table=5,cookie=0x${ovs_port},priority=100,ip,nw_dst=${ipaddr},reg0=${tenant_id},actions=output:${ovs_port}"
+      ovs-ofctl -O OpenFlow13 add-flow br0 "table=6,cookie=0x${ovs_port},priority=100,ip,nw_dst=${ipaddr},reg0=${tenant_id},actions=output:${ovs_port}"
     fi
 
     add_subnet_route="ip route add ${cluster_subnet} dev eth0 proto kernel scope link src $ipaddr"
@@ -79,7 +79,7 @@ Teardown() {
     ovs_port=$(ovs-ofctl -O OpenFlow13 dump-ports-desc br0  | grep ${veth_host} | cut -d "(" -f 1 | tr -d ' ')
     ovs-vsctl del-port $veth_host
     ovs-ofctl -O OpenFlow13 del-flows br0 "table=3,cookie=0x${ovs_port}/0xffffffff"
-    ovs-ofctl -O OpenFlow13 del-flows br0 "table=5,cookie=0x${ovs_port}/0xffffffff"
+    ovs-ofctl -O OpenFlow13 del-flows br0 "table=6,cookie=0x${ovs_port}/0xffffffff"
 }
 
 case "$action" in

--- a/ovssubnet/controller/multitenant/multitenant.go
+++ b/ovssubnet/controller/multitenant/multitenant.go
@@ -7,8 +7,10 @@ import (
 	"net"
 	"os/exec"
 	"strconv"
+	"strings"
 	"syscall"
 
+	"github.com/openshift/openshift-sdn/ovssubnet/api"
 	"github.com/openshift/openshift-sdn/pkg/netutils"
 )
 
@@ -19,11 +21,11 @@ func NewFlowController() *FlowController {
 	return &FlowController{}
 }
 
-func (c *FlowController) Setup(localSubnet, containerNetwork string) error {
+func (c *FlowController) Setup(localSubnet, containerNetwork, servicesNetwork string) error {
 	_, ipnet, err := net.ParseCIDR(localSubnet)
 	subnetMaskLength, _ := ipnet.Mask.Size()
 	gateway := netutils.GenerateDefaultGateway(ipnet).String()
-	out, err := exec.Command("openshift-sdn-multitenant-setup.sh", gateway, ipnet.String(), containerNetwork, strconv.Itoa(subnetMaskLength), gateway).CombinedOutput()
+	out, err := exec.Command("openshift-sdn-multitenant-setup.sh", gateway, ipnet.String(), containerNetwork, strconv.Itoa(subnetMaskLength), gateway, servicesNetwork).CombinedOutput()
 	log.Infof("Output of setup script:\n%s", out)
 	if err != nil {
 		exitErr, ok := err.(*exec.ExitError)
@@ -45,8 +47,8 @@ func (c *FlowController) AddOFRules(nodeIP, subnet, localIP string) error {
 	}
 
 	cookie := generateCookie(nodeIP)
-	iprule := fmt.Sprintf("table=6,cookie=0x%s,priority=100,ip,nw_dst=%s,actions=move:NXM_NX_REG0[]->NXM_NX_TUN_ID[0..31],set_field:%s->tun_dst,output:1", cookie, subnet, nodeIP)
-	arprule := fmt.Sprintf("table=7,cookie=0x%s,priority=100,arp,nw_dst=%s,actions=move:NXM_NX_REG0[]->NXM_NX_TUN_ID[0..31],set_field:%s->tun_dst,output:1", cookie, subnet, nodeIP)
+	iprule := fmt.Sprintf("table=7,cookie=0x%s,priority=100,ip,nw_dst=%s,actions=move:NXM_NX_REG0[]->NXM_NX_TUN_ID[0..31],set_field:%s->tun_dst,output:1", cookie, subnet, nodeIP)
+	arprule := fmt.Sprintf("table=8,cookie=0x%s,priority=100,arp,nw_dst=%s,actions=move:NXM_NX_REG0[]->NXM_NX_TUN_ID[0..31],set_field:%s->tun_dst,output:1", cookie, subnet, nodeIP)
 	o, e := exec.Command("ovs-ofctl", "-O", "OpenFlow13", "add-flow", "br0", iprule).CombinedOutput()
 	log.Infof("Output of adding %s: %s (%v)", iprule, o, e)
 	o, e = exec.Command("ovs-ofctl", "-O", "OpenFlow13", "add-flow", "br0", arprule).CombinedOutput()
@@ -61,8 +63,8 @@ func (c *FlowController) DelOFRules(node, localIP string) error {
 
 	log.Infof("Calling del rules for %s", node)
 	cookie := generateCookie(node)
-	iprule := fmt.Sprintf("table=6,cookie=0x%s/0xffffffff", cookie)
-	arprule := fmt.Sprintf("table=7,cookie=0x%s/0xffffffff", cookie)
+	iprule := fmt.Sprintf("table=7,cookie=0x%s/0xffffffff", cookie)
+	arprule := fmt.Sprintf("table=8,cookie=0x%s/0xffffffff", cookie)
 	o, e := exec.Command("ovs-ofctl", "-O", "OpenFlow13", "del-flows", "br0", iprule).CombinedOutput()
 	log.Infof("Output of deleting local ip rules %s (%v)", o, e)
 	o, e = exec.Command("ovs-ofctl", "-O", "OpenFlow13", "del-flows", "br0", arprule).CombinedOutput()
@@ -72,4 +74,26 @@ func (c *FlowController) DelOFRules(node, localIP string) error {
 
 func generateCookie(ip string) string {
 	return hex.EncodeToString(net.ParseIP(ip).To4())
+}
+
+func (c *FlowController) AddServiceOFRules(netID uint, IP string, protocol api.ServiceProtocol, port uint) error {
+	rule := generateServiceRule(netID, IP, protocol, port)
+	o, e := exec.Command("ovs-ofctl", "-O", "OpenFlow13", "add-flow", "br0", rule).CombinedOutput()
+	log.Infof("Output of adding %s: %s (%v)", rule, o, e)
+	return e
+}
+
+func (c *FlowController) DelServiceOFRules(netID uint, IP string, protocol api.ServiceProtocol, port uint) error {
+	rule := generateServiceRule(netID, IP, protocol, port)
+	o, e := exec.Command("ovs-ofctl", "-O", "OpenFlow13", "del-flows", "br0", rule).CombinedOutput()
+	log.Infof("Output of deleting %s: %s (%v)", rule, o, e)
+	return e
+}
+
+func generateServiceRule(netID uint, IP string, protocol api.ServiceProtocol, port uint) string {
+	if netID == 0 {
+		return fmt.Sprintf("table=4,priority=200,%s,nw_dst=%s,tp_dst=%d,actions=output:2", strings.ToLower(string(protocol)), IP, port)
+	} else {
+		return fmt.Sprintf("table=4,priority=200,reg0=%d,%s,nw_dst=%s,tp_dst=%d,actions=output:2", netID, strings.ToLower(string(protocol)), IP, port)
+	}
 }

--- a/ovssubnet/registry/registry.go
+++ b/ovssubnet/registry/registry.go
@@ -166,6 +166,14 @@ func (sub *EtcdSubnetRegistry) GetNodes() (*[]string, error) {
 	return &nodes, nil
 }
 
+func (sub *EtcdSubnetRegistry) InitServices() error {
+	return nil
+}
+
+func (sub *EtcdSubnetRegistry) GetServices() (*[]api.Service, error) {
+	return nil, nil
+}
+
 func (sub *EtcdSubnetRegistry) GetSubnets() (*[]api.Subnet, error) {
 	key := sub.etcdCfg.SubnetPath
 	resp, err := sub.client().Get(key, false, true)
@@ -211,7 +219,7 @@ func (sub *EtcdSubnetRegistry) DeleteSubnet(nodeName string) error {
 	return err
 }
 
-func (sub *EtcdSubnetRegistry) WriteNetworkConfig(network string, subnetLength uint) error {
+func (sub *EtcdSubnetRegistry) WriteNetworkConfig(network string, subnetLength uint, serviceNetwork string) error {
 	key := path.Join(sub.etcdCfg.SubnetConfigPath, "ContainerNetwork")
 	_, err := sub.client().Create(key, network, 0)
 	if err != nil {
@@ -243,6 +251,11 @@ func (sub *EtcdSubnetRegistry) GetContainerNetwork() (string, error) {
 		return "", err
 	}
 	return resp.Node.Value, err
+}
+
+func (sub *EtcdSubnetRegistry) GetServicesNetwork() (string, error) {
+	// FIXME
+	return "172.30.0.0/16", nil
 }
 
 func (sub *EtcdSubnetRegistry) GetSubnetLength() (uint64, error) {
@@ -329,6 +342,10 @@ func (sub *EtcdSubnetRegistry) watch(key string, rev uint64, stop chan bool) (*e
 	}
 
 	return rawResp.Unmarshal()
+}
+
+func (sub *EtcdSubnetRegistry) WatchServices(receiver chan *api.ServiceEvent, stop chan bool) error {
+	return nil
 }
 
 func (sub *EtcdSubnetRegistry) WatchSubnets(receiver chan *api.SubnetEvent, stop chan bool) error {


### PR DESCRIPTION
OK, resubmitting the service isolation stuff. You can diff against danwinship/openshift-sdn service-isolation-old to see what's changed; basically it's just adding the service network to StartMaster and WriteNetworkConfig, which is needed in the origin osdn plugin to get that into the ClusterNetwork.
