### PR TITLE
Get node IP from GetNodes() instead of net.Lookup()

### DIFF
--- a/ovssubnet/api/types.go
+++ b/ovssubnet/api/types.go
@@ -16,7 +16,7 @@ type SubnetRegistry interface {
 	WatchSubnets(receiver chan *SubnetEvent, stop chan bool) error
 
 	InitNodes() error
-	GetNodes() (*[]string, error)
+	GetNodes() ([]Node, error)
 	CreateNode(nodeName string, data string) error
 	WatchNodes(receiver chan *NodeEvent, stop chan bool) error
 
@@ -33,21 +33,25 @@ type SubnetRegistry interface {
 	DeleteNetNamespace(name string) error
 }
 
+type Subnet struct {
+	NodeIP   string
+	SubnetIP string
+}
+
 type SubnetEvent struct {
 	Type     EventType
 	NodeName string
 	Subnet   Subnet
 }
 
-type NodeEvent struct {
-	Type     EventType
-	NodeName string
-	NodeIP   string
+type Node struct {
+	Name string
+	IP   string
 }
 
-type Subnet struct {
-	NodeIP   string
-	SubnetIP string
+type NodeEvent struct {
+	Type EventType
+	Node Node
 }
 
 type NetNamespace struct {

--- a/ovssubnet/common.go
+++ b/ovssubnet/common.go
@@ -64,19 +64,10 @@ func NewDefaultController(sub api.SubnetRegistry, hostname string, selfIP string
 
 func NewController(sub api.SubnetRegistry, hostname string, selfIP string, ready chan struct{}) (*OvsController, error) {
 	if selfIP == "" {
-		addrs, err := net.LookupIP(hostname)
+		var err error
+		selfIP, err = getNodeIP(hostname)
 		if err != nil {
-			log.Errorf("Failed to lookup IP Address for %s", hostname)
 			return nil, err
-		}
-		for _, addr := range addrs {
-			if addr.String() != "127.0.0.1" {
-				selfIP = addr.String()
-				break
-			}
-		}
-		if selfIP == "" {
-			return nil, fmt.Errorf("failed to lookup valid IP Address for %s (%v)", hostname, addrs)
 		}
 	}
 	log.Infof("Self IP: %s.", selfIP)
@@ -210,39 +201,18 @@ func (oc *OvsController) ServeExistingNodes() error {
 		return err
 	}
 
-	for _, nodeName := range *nodes {
-		_, err := oc.subnetRegistry.GetSubnet(nodeName)
+	for _, node := range nodes {
+		_, err := oc.subnetRegistry.GetSubnet(node.Name)
 		if err == nil {
 			// subnet already exists, continue
 			continue
 		}
-		err = oc.AddNode(nodeName, "")
+		err = oc.AddNode(node.Name, node.IP)
 		if err != nil {
 			return err
 		}
 	}
 	return nil
-}
-
-func (oc *OvsController) getNodeIP(nodeName string) (string, error) {
-	ip := net.ParseIP(nodeName)
-	if ip == nil {
-		addrs, err := net.LookupIP(nodeName)
-		if err != nil {
-			log.Errorf("Failed to lookup IP address for node %s: %v", nodeName, err)
-			return "", err
-		}
-		for _, addr := range addrs {
-			if addr.String() != "127.0.0.1" {
-				ip = addr
-				break
-			}
-		}
-	}
-	if ip == nil || len(ip.String()) == 0 {
-		return "", fmt.Errorf("Failed to obtain IP address from node label: %s", nodeName)
-	}
-	return ip.String(), nil
 }
 
 func (oc *OvsController) AddNode(nodeName string, nodeIP string) error {
@@ -253,10 +223,7 @@ func (oc *OvsController) AddNode(nodeName string, nodeIP string) error {
 	}
 
 	if nodeIP == "" || nodeIP == "127.0.0.1" {
-		nodeIP, err = oc.getNodeIP(nodeName)
-		if err != nil {
-			return err
-		}
+		return fmt.Errorf("Invalid node IP")
 	}
 
 	subnet := &api.Subnet{
@@ -388,29 +355,29 @@ func (oc *OvsController) watchNodes() {
 		case ev := <-nodeEvent:
 			switch ev.Type {
 			case api.Added:
-				sub, err := oc.subnetRegistry.GetSubnet(ev.NodeName)
+				sub, err := oc.subnetRegistry.GetSubnet(ev.Node.Name)
 				if err != nil {
 					// subnet does not exist already
-					oc.AddNode(ev.NodeName, ev.NodeIP)
+					oc.AddNode(ev.Node.Name, ev.Node.IP)
 				} else {
 					// Current node IP is obtained from event, ev.NodeIP to
 					// avoid cached/stale IP lookup by net.LookupIP()
-					if sub.NodeIP != ev.NodeIP {
-						err = oc.subnetRegistry.DeleteSubnet(ev.NodeName)
+					if sub.NodeIP != ev.Node.IP {
+						err = oc.subnetRegistry.DeleteSubnet(ev.Node.Name)
 						if err != nil {
-							log.Errorf("Error deleting subnet for node %s, old ip %s", ev.NodeName, sub.NodeIP)
+							log.Errorf("Error deleting subnet for node %s, old ip %s", ev.Node.Name, sub.NodeIP)
 							continue
 						}
-						sub.NodeIP = ev.NodeIP
-						err = oc.subnetRegistry.CreateSubnet(ev.NodeName, sub)
+						sub.NodeIP = ev.Node.IP
+						err = oc.subnetRegistry.CreateSubnet(ev.Node.Name, sub)
 						if err != nil {
-							log.Errorf("Error creating subnet for node %s, ip %s", ev.NodeName, sub.NodeIP)
+							log.Errorf("Error creating subnet for node %s, ip %s", ev.Node.Name, sub.NodeIP)
 							continue
 						}
 					}
 				}
 			case api.Deleted:
-				oc.DeleteNode(ev.NodeName)
+				oc.DeleteNode(ev.Node.Name)
 			}
 		case <-oc.sig:
 			log.Error("Signal received. Stopping watching of nodes.")
@@ -445,4 +412,25 @@ func (oc *OvsController) watchCluster() {
 func (oc *OvsController) Stop() {
 	close(oc.sig)
 	//oc.sig <- struct{}{}
+}
+
+func getNodeIP(nodeName string) (string, error) {
+	ip := net.ParseIP(nodeName)
+	if ip == nil {
+		addrs, err := net.LookupIP(nodeName)
+		if err != nil {
+			log.Errorf("Failed to lookup IP address for node %s: %v", nodeName, err)
+			return "", err
+		}
+		for _, addr := range addrs {
+			if addr.String() != "127.0.0.1" {
+				ip = addr
+				break
+			}
+		}
+	}
+	if ip == nil || len(ip.String()) == 0 {
+		return "", fmt.Errorf("Failed to obtain IP address from node name: %s", nodeName)
+	}
+	return ip.String(), nil
 }

--- a/ovssubnet/registry/registry.go
+++ b/ovssubnet/registry/registry.go
@@ -40,22 +40,12 @@ func newNodeEvent(action, key, value string) *api.NodeEvent {
 	}
 
 	if key != "" {
-		_, nodeEvent.NodeName = path.Split(key)
+		_, nodeEvent.Node.Name = path.Split(key)
 
-		var node map[string]interface{}
-		err := json.Unmarshal([]byte(value), &node)
+		nodeIP, err := getNodeIP(value)
 		if err == nil {
-			nodeStatus, ok := node["Status"].(map[string]interface{})
-			if ok {
-				nodeAddresses, ok := nodeStatus["Addresses"].([]interface{})
-				if ok {
-					nodeAddressMap, ok := nodeAddresses[0].(map[string]interface{})
-					if ok {
-						nodeEvent.NodeIP = nodeAddressMap["Address"].(string)
-						return nodeEvent
-					}
-				}
-			}
+			nodeEvent.Node.IP = nodeIP
+			return nodeEvent
 		}
 	}
 
@@ -142,7 +132,7 @@ func (sub *EtcdSubnetRegistry) InitNodes() error {
 	return err
 }
 
-func (sub *EtcdSubnetRegistry) GetNodes() (*[]string, error) {
+func (sub *EtcdSubnetRegistry) GetNodes() ([]api.Node, error) {
 	key := sub.etcdCfg.NodePath
 	resp, err := sub.client().Get(key, false, true)
 	if err != nil {
@@ -153,17 +143,22 @@ func (sub *EtcdSubnetRegistry) GetNodes() (*[]string, error) {
 		return nil, errors.New("Node path is not a directory")
 	}
 
-	nodes := make([]string, 0)
+	nodes := make([]api.Node, 0)
 
 	for _, node := range resp.Node.Nodes {
 		if node.Key == "" {
 			log.Errorf("Error unmarshalling GetNodes response node %s", node.Key)
 			continue
 		}
-		_, node := path.Split(node.Key)
-		nodes = append(nodes, node)
+		_, nodeName := path.Split(node.Key)
+
+		nodeIP, err := getNodeIP(node.Value)
+		if err != nil {
+			return nil, err
+		}
+		nodes = append(nodes, api.Node{Name: nodeName, IP: nodeIP})
 	}
-	return &nodes, nil
+	return nodes, nil
 }
 
 func (sub *EtcdSubnetRegistry) GetSubnets() (*[]api.Subnet, error) {
@@ -397,4 +392,23 @@ func (sub *EtcdSubnetRegistry) resetClient() {
 	if err != nil {
 		panic(fmt.Errorf("resetClient: error recreating etcd client: %v", err))
 	}
+}
+
+func getNodeIP(nodeRawObject string) (string, error) {
+	var node map[string]interface{}
+
+	err := json.Unmarshal([]byte(nodeRawObject), &node)
+	if err == nil {
+		nodeStatus, ok := node["Status"].(map[string]interface{})
+		if ok {
+			nodeAddresses, ok := nodeStatus["Addresses"].([]interface{})
+			if ok {
+				nodeAddressMap, ok := nodeAddresses[0].(map[string]interface{})
+				if ok {
+					return nodeAddressMap["Address"].(string), nil
+				}
+			}
+		}
+	}
+	return "", fmt.Errorf("Error decoding node raw object: %s", nodeRawObject)
 }


### PR DESCRIPTION
This will avoid cases where node IP resolution on
master and node differs for various reasons (stale dns cache, etc.)
