### PR TITLE
Implement kubernetes status hook in kube plugin

### DIFF
--- a/ovssubnet/controller/kube/bin/openshift-ovs-subnet
+++ b/ovssubnet/controller/kube/bin/openshift-ovs-subnet
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -ex
+set -e
 
 lock_file=/var/lock/openshift-sdn.lock
 
@@ -74,15 +74,29 @@ Teardown() {
     ovs-ofctl -O OpenFlow13 del-flows br0 "table=0,cookie=0x${ovs_port}/0xffffffff"
 }
 
+Status() {
+    ipaddr=$(docker inspect --format "{{.NetworkSettings.IPAddress}}" ${net_container})
+    if [ -z "$ipaddr" ]; then
+	exit 1
+    fi
+
+    printf "{ \"kind\": \"PodNetworkStatus\", \"apiVersion\": \"v1beta1\", \"ip\": \"${ipaddr}\" }\n"
+}
+
 case "$action" in
     init)
 	lockwrap Init
 	;;
     setup)
+	set -x
 	lockwrap Setup
 	;;
     teardown)
+	set -x
 	lockwrap Teardown
+	;;
+    status)
+	lockwrap Status
 	;;
     *)
         echo "Bad input: $@"


### PR DESCRIPTION
Pretty simple. The only trick is that we have to remove the global "set -x" since the exec plugin tries to parse the combined stderr+stdout for the status, so we can't use -x on the status hook.

Closes #142. (The multitenant plugin side is in origin, not openshift-sdn, and will be addressed by https://github.com/openshift/origin/issues/4170.)