### PR TITLE
Fix race condition in pkg/netutils/server/server_test.go

### DIFF
--- a/ovssubnet/controller/kube/kube.go
+++ b/ovssubnet/controller/kube/kube.go
@@ -66,7 +66,6 @@ func (c *FlowController) manageLocalIpam(ipnet *net.IPNet) error {
 		return err
 	}
 	f.Close()
-	// listen and serve does not return the control
 	netutils_server.ListenAndServeNetutilServer(ipam, net.ParseIP(ipamHost), ipamPort, nil)
 	return nil
 }

--- a/pkg/netutils/server/server_test.go
+++ b/pkg/netutils/server/server_test.go
@@ -45,7 +45,7 @@ func TestIPServe(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Error while initializing IPAM: %v", err)
 	}
-	go ListenAndServeNetutilServer(ipam, net.ParseIP("127.0.0.1"), 9080, nil)
+	ListenAndServeNetutilServer(ipam, net.ParseIP("127.0.0.1"), 9080, nil)
 
 	// get, get, delete, get
 	ip := getIP(t)


### PR DESCRIPTION
TestIPServe() was running ListenAndServeNetutilServer() in a goroutine but not necessarily waiting for it to actually start listening. Fix that by having ListenAndServeNetutilServer() first listen and then
spawn a goroutine to serve, and then return, and having TestIPServe() wait for it to return.

Closes #134

(Not that we're actually using this code anyway any more... if we don't expect to use it in the future maybe we should just remove pkg/netutil/server ?)