### PR TITLE
Cleanup docker0 interface before restarting docker

### DIFF
--- a/ovssubnet/controller/kube/bin/openshift-sdn-kube-subnet-setup.sh
+++ b/ovssubnet/controller/kube/bin/openshift-sdn-kube-subnet-setup.sh
@@ -122,6 +122,10 @@ EOF
         sysctl -w net.bridge.bridge-nf-call-iptables=0
     fi
 
+    # Cleanup docker0 since docker won't do it
+    ip link set docker0 down || true
+    brctl delbr docker0 || true
+
     # enable IP forwarding for ipv4 packets
     sysctl -w net.ipv4.ip_forward=1
     sysctl -w net.ipv4.conf.${TUN}.forwarding=1

--- a/ovssubnet/controller/lbr/bin/openshift-sdn-simple-setup-node.sh
+++ b/ovssubnet/controller/lbr/bin/openshift-sdn-simple-setup-node.sh
@@ -67,3 +67,7 @@ EOF
 
 systemctl daemon-reload
 systemctl restart docker.service
+
+# Cleanup docker0 since docker won't do it
+ip link set docker0 down || true
+brctl delbr docker0 || true

--- a/ovssubnet/controller/multitenant/bin/openshift-sdn-multitenant-setup.sh
+++ b/ovssubnet/controller/multitenant/bin/openshift-sdn-multitenant-setup.sh
@@ -148,6 +148,10 @@ EOF
         sysctl -w net.bridge.bridge-nf-call-iptables=0
     fi
 
+    # Cleanup docker0 since docker won't do it
+    ip link set docker0 down || true
+    brctl delbr docker0 || true
+
     # enable IP forwarding for ipv4 packets
     sysctl -w net.ipv4.ip_forward=1
     sysctl -w net.ipv4.conf.${TUN}.forwarding=1


### PR DESCRIPTION
Docker creates docker0 with a 172.16/16 route by default, and does not clean it up on exit.  This interface is not used with OpenShift-SDN and the routing simply conflicts with existing hosts folks may have in this private IP range.

OpenShift-SDN creates a bridge (lbr0) for Docker to use, however it is brought up after the 1st start of the docker service on boot, hence docker0 is always created.  The sequence is as follows (for OpenShift):
- docker service (which ​creates docker0 b.c. lbr0 does not exist yet)
- openshift-node service (with openshift-sdn-ovs linked in)
    - starts /usr/bin/openshift-sdn-kube-subnet-setup.sh
        - (*) creates /run/openshift-sdn/docker-network with "-b lbr0 ...", and of course lbr0 amongst others
        - restarts docker

So it looks like the cleanest place to get rid of docker0 is from the (*) in the above sequence onwards, and is implemented by this patch.