### PR TITLE
Make "default" an admin namespace

### DIFF
--- a/ovssubnet/common.go
+++ b/ovssubnet/common.go
@@ -85,7 +85,7 @@ func NewController(sub api.SubnetRegistry, hostname string, selfIP string, ready
 		VNIDMap:         make(map[string]uint),
 		sig:             make(chan struct{}),
 		ready:           ready,
-		AdminNamespaces: make([]string, 0),
+		AdminNamespaces: []string{"default"},
 	}, nil
 }
 


### PR DESCRIPTION
Not sure at what point this got broken since I'm pretty sure it used to work, but anyway, we're currently not actually using VNID 0 for namespace "default", so it doesn't work...
