### PR TITLE
omit reconstructing IP address with docker inspect

### DIFF
--- a/pkg/ovssubnet/controller/kube/bin/openshift-ovs-subnet
+++ b/pkg/ovssubnet/controller/kube/bin/openshift-ovs-subnet
@@ -67,12 +67,7 @@ Teardown() {
 }
 
 Status() {
-    ipaddr=$(docker inspect --format "{{.NetworkSettings.IPAddress}}" ${net_container})
-    if [ -z "$ipaddr" ]; then
-	exit 1
-    fi
-
-    printf "{ \"kind\": \"PodNetworkStatus\", \"apiVersion\": \"v1beta1\", \"ip\": \"${ipaddr}\" }\n"
+    # do nothing, empty output will default to address as picked by docker
 }
 
 case "$action" in

--- a/pkg/ovssubnet/controller/multitenant/bin/openshift-ovs-multitenant
+++ b/pkg/ovssubnet/controller/multitenant/bin/openshift-ovs-multitenant
@@ -75,12 +75,7 @@ Teardown() {
 }
 
 Status() {
-    ipaddr=$(docker inspect --format "{{.NetworkSettings.IPAddress}}" ${net_container})
-    if [ -z "$ipaddr" ]; then
-	exit 1
-    fi
-
-    printf "{ \"kind\": \"PodNetworkStatus\", \"apiVersion\": \"v1beta1\", \"ip\": \"${ipaddr}\" }\n"
+    # do nothing, empty output will default to address as picked by docker
 }
 
 case "$action" in


### PR DESCRIPTION
Outputting nothing will lead to the default from 'docker inspect' itself. So avoid multiple pounding of docker daemon with docker inspect calls.