### PR TITLE
Use iptables -w flag

### DIFF
--- a/pkg/ovssubnet/common.go
+++ b/pkg/ovssubnet/common.go
@@ -3,11 +3,13 @@ package ovssubnet
 import (
 	"fmt"
 	"net"
+	"os/exec"
 	"strings"
 	"time"
 
 	log "github.com/golang/glog"
 
+	"github.com/openshift/openshift-sdn/pkg/firewalld"
 	"github.com/openshift/openshift-sdn/pkg/netutils"
 	"github.com/openshift/openshift-sdn/pkg/ovssubnet/api"
 	"github.com/openshift/openshift-sdn/pkg/ovssubnet/controller/kube"
@@ -309,6 +311,19 @@ func (oc *OvsController) StartNode(mtu uint) error {
 		return err
 	}
 
+	fw := firewalld.New()
+	err = SetupIptables(fw, clusterNetworkCIDR)
+	if err != nil {
+		return err
+	}
+
+	fw.AddReloadFunc(func() {
+		err := SetupIptables(fw, clusterNetworkCIDR)
+		if err != nil {
+			log.Errorf("Error reloading iptables: %v\n", err)
+		}
+	})
+
 	result, err := oc.watchAndGetResource("HostSubnet")
 	if err != nil {
 		return err
@@ -555,4 +570,39 @@ func (oc *OvsController) watchAndGetResource(resourceName string) (interface{}, 
 	start <- version
 
 	return getOutput, nil
+}
+
+type FirewallRule struct {
+	ipv      string
+	table    string
+	chain    string
+	priority int
+	args     []string
+}
+
+func SetupIptables(fw *firewalld.Interface, clusterNetworkCIDR string) error {
+	if fw.IsRunning() {
+		rules := []FirewallRule{
+			{firewalld.IPv4, "nat", "POSTROUTING", 0, []string{"-s", clusterNetworkCIDR, "!", "-d", clusterNetworkCIDR, "-j", "MASQUERADE"}},
+			{firewalld.IPv4, "filter", "INPUT", 0, []string{"-p", "udp", "-m", "multiport", "--dports", "4789", "-m", "comment", "--comment", "001 vxlan incoming", "-j", "ACCEPT"}},
+			{firewalld.IPv4, "filter", "INPUT", 0, []string{"-i", "tun0", "-m", "comment", "--comment", "traffic from docker for internet", "-j", "ACCEPT"}},
+			{firewalld.IPv4, "filter", "FORWARD", 0, []string{"-d", clusterNetworkCIDR, "-j", "ACCEPT"}},
+			{firewalld.IPv4, "filter", "FORWARD", 0, []string{"-s", clusterNetworkCIDR, "-j", "ACCEPT"}},
+		}
+
+		for _, rule := range rules {
+			err := fw.EnsureRule(rule.ipv, rule.table, rule.chain, rule.priority, rule.args)
+			if err != nil {
+				return err
+			}
+		}
+	} else {
+		exec.Command("iptables", "-t", "nat", "-D", "POSTROUTING", "-s", clusterNetworkCIDR, "!", "-d", clusterNetworkCIDR, "-j", "MASQUERADE").Run()
+		err := exec.Command("iptables", "-t", "nat", "-A", "POSTROUTING", "-s", clusterNetworkCIDR, "!", "-d", clusterNetworkCIDR, "-j", "MASQUERADE").Run()
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
 }

--- a/pkg/ovssubnet/controller/kube/bin/openshift-sdn-kube-subnet-setup.sh
+++ b/pkg/ovssubnet/controller/kube/bin/openshift-sdn-kube-subnet-setup.sh
@@ -125,18 +125,6 @@ function setup() {
     ip link set ${TUN} up
     ip route add ${cluster_network_cidr} dev ${TUN} proto kernel scope link
 
-    ## iptables
-    iptables -t nat -D POSTROUTING -s ${cluster_network_cidr} ! -d ${cluster_network_cidr} -j MASQUERADE || true
-    iptables -t nat -A POSTROUTING -s ${cluster_network_cidr} ! -d ${cluster_network_cidr} -j MASQUERADE
-    iptables -D INPUT -p udp -m multiport --dports 4789 -m comment --comment "001 vxlan incoming" -j ACCEPT || true
-    iptables -D INPUT -i ${TUN} -m comment --comment "traffic from docker for internet" -j ACCEPT || true
-    lineno=$(iptables -nvL INPUT --line-numbers | grep "state RELATED,ESTABLISHED" | awk '{print $1}')
-    iptables -I INPUT $lineno -p udp -m multiport --dports 4789 -m comment --comment "001 vxlan incoming" -j ACCEPT
-    iptables -I INPUT $((lineno+1)) -i ${TUN} -m comment --comment "traffic from docker for internet" -j ACCEPT
-    fwd_lineno=$(iptables -nvL FORWARD --line-numbers | grep "reject-with icmp-host-prohibited" | tail -n 1 | awk '{print $1}')
-    iptables -I FORWARD $fwd_lineno -d ${cluster_network_cidr} -j ACCEPT
-    iptables -I FORWARD $fwd_lineno -s ${cluster_network_cidr} -j ACCEPT
-
     ## docker
     docker_network_config update
 

--- a/pkg/ovssubnet/controller/multitenant/multitenant.go
+++ b/pkg/ovssubnet/controller/multitenant/multitenant.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 	"syscall"
 
-	"github.com/openshift/openshift-sdn/pkg/firewalld"
 	"github.com/openshift/openshift-sdn/pkg/netutils"
 	"github.com/openshift/openshift-sdn/pkg/ovssubnet/api"
 )
@@ -33,64 +32,12 @@ func (c *FlowController) Setup(localSubnetCIDR, clusterNetworkCIDR, servicesNetw
 			status := exitErr.ProcessState.Sys().(syscall.WaitStatus)
 			if status.Exited() && status.ExitStatus() == 140 {
 				// valid, do nothing, its just a benevolent restart
-				err = nil
+				return nil
 			}
 		}
-	}
-	if err != nil {
 		log.Errorf("Error executing setup script. \n\tOutput: %s\n\tError: %v\n", out, err)
 		return err
 	}
-
-	fw := firewalld.New()
-	err = c.SetupIptables(fw, clusterNetworkCIDR)
-	if err != nil {
-		log.Errorf("Error setting up iptables: %v\n", err)
-		return err
-	}
-
-	fw.AddReloadFunc(func() {
-		err = c.SetupIptables(fw, clusterNetworkCIDR)
-		if err != nil {
-			log.Errorf("Error reloading iptables: %v\n", err)
-		}
-	})
-
-	return nil
-}
-
-type FirewallRule struct {
-	ipv      string
-	table    string
-	chain    string
-	priority int
-	args     []string
-}
-
-func (c *FlowController) SetupIptables(fw *firewalld.Interface, clusterNetworkCIDR string) error {
-	if fw.IsRunning() {
-		rules := []FirewallRule{
-			{firewalld.IPv4, "nat", "POSTROUTING", 0, []string{"-s", clusterNetworkCIDR, "!", "-d", clusterNetworkCIDR, "-j", "MASQUERADE"}},
-			{firewalld.IPv4, "filter", "INPUT", 0, []string{"-p", "udp", "-m", "multiport", "--dports", "4789", "-m", "comment", "--comment", "001 vxlan incoming", "-j", "ACCEPT"}},
-			{firewalld.IPv4, "filter", "INPUT", 0, []string{"-i", "tun0", "-m", "comment", "--comment", "traffic from docker for internet", "-j", "ACCEPT"}},
-			{firewalld.IPv4, "filter", "FORWARD", 0, []string{"-d", clusterNetworkCIDR, "-j", "ACCEPT"}},
-			{firewalld.IPv4, "filter", "FORWARD", 0, []string{"-s", clusterNetworkCIDR, "-j", "ACCEPT"}},
-		}
-
-		for _, rule := range rules {
-			err := fw.EnsureRule(rule.ipv, rule.table, rule.chain, rule.priority, rule.args)
-			if err != nil {
-				return err
-			}
-		}
-	} else {
-		exec.Command("iptables", "-t", "nat", "-D", "POSTROUTING", "-s", clusterNetworkCIDR, "!", "-d", clusterNetworkCIDR, "-j", "MASQUERADE").Run()
-		err := exec.Command("iptables", "-t", "nat", "-A", "POSTROUTING", "-s", clusterNetworkCIDR, "!", "-d", clusterNetworkCIDR, "-j", "MASQUERADE").Run()
-		if err != nil {
-			return err
-		}
-	}
-
 	return nil
 }
 


### PR DESCRIPTION
To avoid problems with iptables locking, we need to use the -w flag, if available. Kubernetes's pkg/util/iptables has code to check for its availability and use it if so, so the simplest fix is to just switch to using that.

(Closes https://bugzilla.redhat.com/show_bug.cgi?id=1267670)