### PR TITLE
Admin command to manage project network

### DIFF
--- a/pkg/cmd/admin/network/isolate_projects.go
+++ b/pkg/cmd/admin/network/isolate_projects.go
@@ -1,0 +1,78 @@
+package network
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/spf13/cobra"
+
+	kcmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
+	kerrors "k8s.io/kubernetes/pkg/util/errors"
+
+	"github.com/openshift/openshift-sdn/plugins/osdn/multitenant"
+	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
+)
+
+const (
+	IsolateProjectsNetworkCommandName = "isolate-projects"
+
+	isolateProjectsNetworkLong = `
+Isolate project network
+
+Allows projects to isolate their network from other projects when using the %[1]s network plugin.`
+
+	isolateProjectsNetworkExample = `	// Provide isolation for project p1
+	$ %[1]s <p1>
+
+	// Allow all projects with label name=top-secret to have their own isolated project network
+	$ %[1]s --selector='name=top-secret'`
+)
+
+type IsolateOptions struct {
+	Options *ProjectOptions
+}
+
+func NewCmdIsolateProjectsNetwork(commandName, fullName string, f *clientcmd.Factory, out io.Writer) *cobra.Command {
+	opts := &ProjectOptions{}
+	isolateOp := &IsolateOptions{Options: opts}
+
+	cmd := &cobra.Command{
+		Use:     commandName,
+		Short:   "Isolate project network",
+		Long:    fmt.Sprintf(isolateProjectsNetworkLong, multitenant.NetworkPluginName()),
+		Example: fmt.Sprintf(isolateProjectsNetworkExample, fullName),
+		Run: func(c *cobra.Command, args []string) {
+			if err := opts.Complete(f, c, args, out); err != nil {
+				kcmdutil.CheckErr(err)
+			}
+			opts.CheckSelector = c.Flag("selector").Changed
+			if err := opts.Validate(); err != nil {
+				kcmdutil.CheckErr(kcmdutil.UsageError(c, err.Error()))
+			}
+
+			err := isolateOp.Run()
+			kcmdutil.CheckErr(err)
+		},
+	}
+	flags := cmd.Flags()
+
+	// Common optional params
+	flags.StringVar(&opts.Selector, "selector", "", "Label selector to filter projects. Either pass one/more projects as arguments or use this project selector")
+
+	return cmd
+}
+
+func (i *IsolateOptions) Run() error {
+	projects, err := i.Options.GetProjects()
+	if err != nil {
+		return err
+	}
+
+	errList := []error{}
+	for _, project := range projects {
+		// TBD: Create or Update network namespace
+		// TODO: Fix this once we move VNID allocation to REST layer
+		errList = append(errList, fmt.Errorf("Project '%s' can not be isolated. Isolate project network feature yet to be implemented!", project.ObjectMeta.Name))
+	}
+	return kerrors.NewAggregate(errList)
+}

--- a/pkg/cmd/admin/network/join_projects.go
+++ b/pkg/cmd/admin/network/join_projects.go
@@ -1,0 +1,100 @@
+package network
+
+import (
+	"errors"
+	"fmt"
+	"io"
+
+	"github.com/spf13/cobra"
+
+	kcmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
+	kerrors "k8s.io/kubernetes/pkg/util/errors"
+
+	"github.com/openshift/openshift-sdn/plugins/osdn/multitenant"
+	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
+)
+
+const (
+	JoinProjectsNetworkCommandName = "join-projects"
+
+	joinProjectsNetworkLong = `
+Join project network
+
+Allows projects to join existing project network when using the %[1]s network plugin.`
+
+	joinProjectsNetworkExample = `	// Allow project p2 to use project p1 network
+	$ %[1]s --to=<p1> <p2>
+
+	// Allow all projects with label name=top-secret to use project p1 network
+	$ %[1]s --to=<p1> --selector='name=top-secret'`
+)
+
+type JoinOptions struct {
+	Options *ProjectOptions
+
+	joinProjectName string
+}
+
+func NewCmdJoinProjectsNetwork(commandName, fullName string, f *clientcmd.Factory, out io.Writer) *cobra.Command {
+	opts := &ProjectOptions{}
+	joinOp := &JoinOptions{Options: opts}
+
+	cmd := &cobra.Command{
+		Use:     commandName,
+		Short:   "Join project network",
+		Long:    fmt.Sprintf(joinProjectsNetworkLong, multitenant.NetworkPluginName()),
+		Example: fmt.Sprintf(joinProjectsNetworkExample, fullName),
+		Run: func(c *cobra.Command, args []string) {
+			if err := opts.Complete(f, c, args, out); err != nil {
+				kcmdutil.CheckErr(err)
+			}
+			opts.CheckSelector = c.Flag("selector").Changed
+			if err := joinOp.Validate(); err != nil {
+				kcmdutil.CheckErr(kcmdutil.UsageError(c, err.Error()))
+			}
+
+			err := joinOp.Run()
+			kcmdutil.CheckErr(err)
+		},
+	}
+	flags := cmd.Flags()
+
+	// Supported operations
+	flags.StringVar(&joinOp.joinProjectName, "to", "", "Join network of the given project name")
+
+	// Common optional params
+	flags.StringVar(&opts.Selector, "selector", "", "Label selector to filter projects. Either pass one/more projects as arguments or use this project selector")
+
+	return cmd
+}
+
+func (j *JoinOptions) Validate() error {
+	errList := []error{}
+	if err := j.Options.Validate(); err != nil {
+		errList = append(errList, err)
+	}
+	if len(j.joinProjectName) == 0 {
+		errList = append(errList, errors.New("must provide --to=<project_name>"))
+	}
+	return kerrors.NewAggregate(errList)
+}
+
+func (j *JoinOptions) Run() error {
+	netID, err := j.Options.GetNetID(j.joinProjectName)
+	if err != nil {
+		return err
+	}
+	projects, err := j.Options.GetProjects()
+	if err != nil {
+		return err
+	}
+
+	errList := []error{}
+	for _, project := range projects {
+		err = j.Options.CreateOrUpdateNetNamespace(project.ObjectMeta.Name, netID)
+		if err != nil {
+			errList = append(errList, fmt.Errorf("Project '%s' failed to join '%s', error: %v", project.ObjectMeta.Name, j.joinProjectName, err))
+		}
+	}
+	return kerrors.NewAggregate(errList)
+}

--- a/pkg/cmd/admin/network/pod_network.go
+++ b/pkg/cmd/admin/network/pod_network.go
@@ -1,0 +1,37 @@
+package network
+
+import (
+	"io"
+
+	"github.com/spf13/cobra"
+
+	cmdutil "github.com/openshift/origin/pkg/cmd/util"
+	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
+)
+
+const PodNetworkCommandName = "pod-network"
+
+const (
+	podNetworkLong = `
+Manage pod network in the cluster
+
+This command provides common pod network operations for administrators.`
+)
+
+func NewCmdPodNetwork(name, fullName string, f *clientcmd.Factory, out io.Writer) *cobra.Command {
+	// Parent command to which all subcommands are added.
+	cmds := &cobra.Command{
+		Use:   name,
+		Short: "Manage pod network",
+		Long:  podNetworkLong,
+		Run:   cmdutil.DefaultSubCommandRun(out),
+	}
+
+	cmds.AddCommand(NewCmdJoinProjectsNetwork(JoinProjectsNetworkCommandName, fullName+" "+JoinProjectsNetworkCommandName, f, out))
+	cmds.AddCommand(NewCmdUnIsolateProjectsNetwork(UnIsolateProjectsNetworkCommandName, fullName+" "+UnIsolateProjectsNetworkCommandName, f, out))
+
+	// TODO: Enable isolate-projects subcommand once we move VNID allocation to REST layer
+	//cmds.AddCommand(NewCmdIsolateProjectsNetwork(IsolateProjectsNetworkCommandName, fullName+" "+IsolateProjectsNetworkCommandName, f, out))
+
+	return cmds
+}

--- a/pkg/cmd/admin/network/project_options.go
+++ b/pkg/cmd/admin/network/project_options.go
@@ -1,0 +1,186 @@
+package network
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"reflect"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	kapi "k8s.io/kubernetes/pkg/api"
+	"k8s.io/kubernetes/pkg/api/meta"
+	kclient "k8s.io/kubernetes/pkg/client/unversioned"
+	"k8s.io/kubernetes/pkg/kubectl/resource"
+	"k8s.io/kubernetes/pkg/labels"
+	"k8s.io/kubernetes/pkg/runtime"
+	kerrors "k8s.io/kubernetes/pkg/util/errors"
+	"k8s.io/kubernetes/pkg/util/sets"
+
+	osclient "github.com/openshift/origin/pkg/client"
+	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
+	"github.com/openshift/origin/pkg/project/api"
+	sdnapi "github.com/openshift/origin/pkg/sdn/api"
+)
+
+type ProjectOptions struct {
+	DefaultNamespace string
+	Oclient          *osclient.Client
+	Kclient          *kclient.Client
+	Out              io.Writer
+
+	Mapper            meta.RESTMapper
+	Typer             runtime.ObjectTyper
+	RESTClientFactory func(mapping *meta.RESTMapping) (resource.RESTClient, error)
+
+	ProjectNames []string
+
+	// Common optional params
+	Selector      string
+	CheckSelector bool
+}
+
+func (p *ProjectOptions) Complete(f *clientcmd.Factory, c *cobra.Command, args []string, out io.Writer) error {
+	defaultNamespace, _, err := f.DefaultNamespace()
+	if err != nil {
+		return err
+	}
+	oc, kc, err := f.Clients()
+	if err != nil {
+		return err
+	}
+	mapper, typer := f.Object()
+
+	p.DefaultNamespace = defaultNamespace
+	p.Oclient = oc
+	p.Kclient = kc
+	p.Out = out
+	p.Mapper = mapper
+	p.Typer = typer
+	p.RESTClientFactory = f.Factory.RESTClient
+	p.ProjectNames = []string{}
+	if len(args) != 0 {
+		p.ProjectNames = append(p.ProjectNames, args...)
+	}
+	return nil
+}
+
+// Common validations
+func (p *ProjectOptions) Validate() error {
+	errList := []error{}
+	if p.CheckSelector {
+		if len(p.Selector) > 0 {
+			if _, err := labels.Parse(p.Selector); err != nil {
+				errList = append(errList, errors.New("--selector=<project_selector> must be a valid label selector"))
+			}
+		}
+		if len(p.ProjectNames) != 0 {
+			errList = append(errList, errors.New("either specify --selector=<project_selector> or projects but not both"))
+		}
+	} else if len(p.ProjectNames) == 0 {
+		errList = append(errList, errors.New("must provide --selector=<project_selector> or projects"))
+	}
+
+	// TODO: Validate if the openshift master is running with mutitenant network plugin
+	return kerrors.NewAggregate(errList)
+}
+
+func (p *ProjectOptions) GetProjects() ([]*api.Project, error) {
+	nameArgs := []string{"projects"}
+	if len(p.ProjectNames) != 0 {
+		nameArgs = append(nameArgs, p.ProjectNames...)
+	}
+
+	r := resource.NewBuilder(p.Mapper, p.Typer, resource.ClientMapperFunc(p.RESTClientFactory)).
+		ContinueOnError().
+		NamespaceParam(p.DefaultNamespace).
+		SelectorParam(p.Selector).
+		ResourceTypeOrNameArgs(true, nameArgs...).
+		Flatten().
+		Do()
+	if r.Err() != nil {
+		return nil, r.Err()
+	}
+
+	errList := []error{}
+	projectList := []*api.Project{}
+	_ = r.Visit(func(info *resource.Info, err error) error {
+		if err != nil {
+			return err
+		}
+		project, ok := info.Object.(*api.Project)
+		if !ok {
+			err := fmt.Errorf("cannot convert input to Project: %v", reflect.TypeOf(info.Object))
+			errList = append(errList, err)
+			// Don't bail out if one project fails
+			return nil
+		}
+		projectList = append(projectList, project)
+		return nil
+	})
+	if len(errList) != 0 {
+		return projectList, kerrors.NewAggregate(errList)
+	}
+
+	if len(projectList) == 0 {
+		return projectList, fmt.Errorf("No projects found")
+	} else {
+		givenProjectNames := sets.NewString(p.ProjectNames...)
+		foundProjectNames := sets.String{}
+		for _, project := range projectList {
+			foundProjectNames.Insert(project.ObjectMeta.Name)
+		}
+		skippedProjectNames := givenProjectNames.Difference(foundProjectNames)
+		if skippedProjectNames.Len() > 0 {
+			return projectList, fmt.Errorf("Projects %v not found", strings.Join(skippedProjectNames.List(), ", "))
+		}
+	}
+	return projectList, nil
+}
+
+func (p *ProjectOptions) GetNetNamespaces() (*sdnapi.NetNamespaceList, error) {
+	netNamespaces, err := p.Oclient.NetNamespaces().List()
+	if err != nil {
+		return nil, err
+	}
+	return netNamespaces, nil
+}
+
+func (p *ProjectOptions) GetNetID(name string) (uint, error) {
+	var netID uint
+	netNamespaces, err := p.GetNetNamespaces()
+	if err != nil {
+		return netID, err
+	}
+
+	for _, netNs := range netNamespaces.Items {
+		if name == netNs.ObjectMeta.Name {
+			return netNs.NetID, nil
+		}
+	}
+	return netID, fmt.Errorf("Net ID not found for project: %s", name)
+}
+
+func (p *ProjectOptions) CreateOrUpdateNetNamespace(name string, id uint) error {
+	netns, err := p.Oclient.NetNamespaces().Get(name)
+	if err != nil {
+		// Create netns
+		netns := newNetNamespace(name, id)
+		_, err = p.Oclient.NetNamespaces().Create(netns)
+	} else if netns.NetID != id {
+		// Update netns
+		netns.NetID = id
+		_, err = p.Oclient.NetNamespaces().Update(netns)
+	}
+	return err
+}
+
+func newNetNamespace(name string, id uint) *sdnapi.NetNamespace {
+	return &sdnapi.NetNamespace{
+		TypeMeta:   kapi.TypeMeta{Kind: "NetNamespace"},
+		ObjectMeta: kapi.ObjectMeta{Name: name},
+		NetName:    name,
+		NetID:      id,
+	}
+}

--- a/pkg/cmd/admin/network/unisolate_projects.go
+++ b/pkg/cmd/admin/network/unisolate_projects.go
@@ -1,0 +1,80 @@
+package network
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/spf13/cobra"
+
+	kcmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
+	kerrors "k8s.io/kubernetes/pkg/util/errors"
+
+	"github.com/openshift/openshift-sdn/pkg/ovssubnet"
+	"github.com/openshift/openshift-sdn/plugins/osdn/multitenant"
+	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
+)
+
+const (
+	UnIsolateProjectsNetworkCommandName = "unisolate-projects"
+
+	unIsolateProjectsNetworkLong = `
+UnIsolate project network
+
+Allows projects to access all pods in the cluster and vice versa when using the %[1]s network plugin.`
+
+	unIsolateProjectsNetworkExample = `	// Allow project p1 to access all pods in the cluster and vice versa
+	$ %[1]s <p1>
+
+	// Allow all projects with label name=share to access all pods in the cluster and vice versa
+	$ %[1]s --selector='name=share'`
+)
+
+type UnIsolateOptions struct {
+	Options *ProjectOptions
+}
+
+func NewCmdUnIsolateProjectsNetwork(commandName, fullName string, f *clientcmd.Factory, out io.Writer) *cobra.Command {
+	opts := &ProjectOptions{}
+	unIsolateOp := &UnIsolateOptions{Options: opts}
+
+	cmd := &cobra.Command{
+		Use:     commandName,
+		Short:   "UnIsolate project network",
+		Long:    fmt.Sprintf(unIsolateProjectsNetworkLong, multitenant.NetworkPluginName()),
+		Example: fmt.Sprintf(unIsolateProjectsNetworkExample, fullName),
+		Run: func(c *cobra.Command, args []string) {
+			if err := opts.Complete(f, c, args, out); err != nil {
+				kcmdutil.CheckErr(err)
+			}
+			opts.CheckSelector = c.Flag("selector").Changed
+			if err := opts.Validate(); err != nil {
+				kcmdutil.CheckErr(kcmdutil.UsageError(c, err.Error()))
+			}
+
+			err := unIsolateOp.Run()
+			kcmdutil.CheckErr(err)
+		},
+	}
+	flags := cmd.Flags()
+
+	// Common optional params
+	flags.StringVar(&opts.Selector, "selector", "", "Label selector to filter projects. Either pass one/more projects as arguments or use this project selector")
+
+	return cmd
+}
+
+func (u *UnIsolateOptions) Run() error {
+	projects, err := u.Options.GetProjects()
+	if err != nil {
+		return err
+	}
+
+	errList := []error{}
+	for _, project := range projects {
+		err = u.Options.CreateOrUpdateNetNamespace(project.ObjectMeta.Name, ovssubnet.AdminVNID)
+		if err != nil {
+			errList = append(errList, fmt.Errorf("Removing network isolation for project '%s' failed, error: %v", project.ObjectMeta.Name, err))
+		}
+	}
+	return kerrors.NewAggregate(errList)
+}

--- a/pkg/ovssubnet/api/types.go
+++ b/pkg/ovssubnet/api/types.go
@@ -32,6 +32,9 @@ type SubnetRegistry interface {
 	GetServicesNetworkCIDR() (string, error)
 	GetServices() ([]Service, string, error)
 	WatchServices(receiver chan<- *ServiceEvent, ready chan<- bool, startVersion <-chan string, stop <-chan bool) error
+	GetServicesForNamespace(namespace string) ([]Service, error)
+
+	GetRunningPods(nodeName, namespace string) ([]Pod, error)
 }
 
 type Subnet struct {
@@ -89,4 +92,10 @@ type Service struct {
 type ServiceEvent struct {
 	Type    EventType
 	Service Service
+}
+
+type Pod struct {
+	Name        string
+	Namespace   string
+	ContainerID string
 }

--- a/pkg/ovssubnet/controller/kube/bin/openshift-ovs-subnet
+++ b/pkg/ovssubnet/controller/kube/bin/openshift-ovs-subnet
@@ -26,44 +26,62 @@ get_veth_host() {
     ip link show | sed -ne "s/^$veth_ifindex: \([^:@]*\).*/\1/p"
 }
 
+get_ipaddr_pid_veth() {
+    network_mode=$(docker inspect --format "{{.HostConfig.NetworkMode}}" ${net_container})
+    if [ "${network_mode}" == "host" ]; then
+      # quit, nothing for the SDN here
+      exit 0
+    elif [[ "${network_mode}" =~ container:.* ]]; then
+      # Get pod infra container
+      net_container=$(echo ${network_mode} | cut -d ":" -f 2)
+    fi
+    ipaddr=$(docker inspect --format "{{.NetworkSettings.IPAddress}}" ${net_container})
+    pid=$(docker inspect --format "{{.State.Pid}}" ${net_container})
+    veth_host=$(get_veth_host $pid)
+}
+
+add_ovs_port() {
+    brctl delif lbr0 $veth_host
+    ovs-vsctl add-port br0 ${veth_host} 
+}
+
+del_ovs_port() {
+    ovs-vsctl del-port $veth_host
+}
+
+add_ovs_flows() {
+    ovs_port=$(ovs-ofctl -O OpenFlow13 dump-ports-desc br0  | grep ${veth_host} | cut -d "(" -f 1 | tr -d ' ')
+
+    ovs-ofctl -O OpenFlow13 add-flow br0 "table=0,cookie=0x${ovs_port},priority=100,ip,nw_dst=${ipaddr},actions=output:${ovs_port}"
+    ovs-ofctl -O OpenFlow13 add-flow br0 "table=0,cookie=0x${ovs_port},priority=100,arp,nw_dst=${ipaddr},actions=output:${ovs_port}"
+}
+
+del_ovs_flows() {
+    ovs_port=$(ovs-ofctl -O OpenFlow13 dump-ports-desc br0  | grep ${veth_host} | cut -d "(" -f 1 | tr -d ' ')
+
+    ovs-ofctl -O OpenFlow13 del-flows br0 "table=0,cookie=0x${ovs_port}/0xffffffff"
+}
+
+add_subnet_route() {
+    source /etc/openshift-sdn/config.env
+    local subnet_route="ip route add ${OPENSHIFT_CLUSTER_SUBNET} dev eth0 proto kernel scope link src $ipaddr"
+    nsenter -n -t $pid -- $subnet_route
+}
+
 Init() {
     true
 }
 
 Setup() {
-    source /etc/openshift-sdn/config.env
-    cluster_subnet=${OPENSHIFT_CLUSTER_SUBNET}
-
-    pid=$(docker inspect --format "{{.State.Pid}}" ${net_container})
-    network_mode=$(docker inspect --format "{{.HostConfig.NetworkMode}}" ${net_container})
-    if [ "${network_mode}" == "host" ]; then
-      # quit, nothing for the SDN here
-      exit 0
-    fi
-    ipaddr=$(docker inspect --format "{{.NetworkSettings.IPAddress}}" ${net_container})
-    veth_host=$(get_veth_host $pid)
-
-    brctl delif lbr0 $veth_host
-    ovs-vsctl add-port br0 ${veth_host} 
-    ovs_port=$(ovs-ofctl -O OpenFlow13 dump-ports-desc br0  | grep ${veth_host} | cut -d "(" -f 1 | tr -d ' ')
-    ovs-ofctl -O OpenFlow13 add-flow br0 "table=0,cookie=0x${ovs_port},priority=100,ip,nw_dst=${ipaddr},actions=output:${ovs_port}"
-    ovs-ofctl -O OpenFlow13 add-flow br0 "table=0,cookie=0x${ovs_port},priority=100,arp,nw_dst=${ipaddr},actions=output:${ovs_port}"
-
-    add_subnet_route="ip route add ${cluster_subnet} dev eth0 proto kernel scope link src $ipaddr"
-    nsenter -n -t $pid -- $add_subnet_route
+    get_ipaddr_pid_veth
+    add_ovs_port
+    add_ovs_flows
 }
 
 Teardown() {
-    pid=$(docker inspect --format "{{.State.Pid}}" ${net_container})
-    network_mode=$(docker inspect --format "{{.HostConfig.NetworkMode}}" ${net_container})
-    if [ "${network_mode}" == "host" ]; then
-      # quit, nothing for the SDN here
-      exit 0
-    fi
-    veth_host=$(get_veth_host $pid)
-    ovs_port=$(ovs-ofctl -O OpenFlow13 dump-ports-desc br0  | grep ${veth_host} | cut -d "(" -f 1 | tr -d ' ')
-    ovs-vsctl del-port $veth_host
-    ovs-ofctl -O OpenFlow13 del-flows br0 "table=0,cookie=0x${ovs_port}/0xffffffff"
+    get_ipaddr_pid_veth
+    del_ovs_port
+    del_ovs_flows
 }
 
 Status() {
@@ -90,4 +108,3 @@ case "$action" in
         echo "Bad input: $@"
         exit 1
 esac
-

--- a/pkg/ovssubnet/controller/kube/kube.go
+++ b/pkg/ovssubnet/controller/kube/kube.go
@@ -107,3 +107,7 @@ func (c *FlowController) AddServiceOFRules(netID uint, IP string, protocol api.S
 func (c *FlowController) DelServiceOFRules(netID uint, IP string, protocol api.ServiceProtocol, port uint) error {
 	return nil
 }
+
+func (c *FlowController) UpdatePod(namespace, podName, containerID string, netID uint) error {
+	return nil
+}

--- a/pkg/ovssubnet/controller/multitenant/bin/openshift-ovs-multitenant
+++ b/pkg/ovssubnet/controller/multitenant/bin/openshift-ovs-multitenant
@@ -28,25 +28,30 @@ get_veth_host() {
     ip link show | sed -ne "s/^$veth_ifindex: \([^:@]*\).*/\1/p"
 }
 
-Init() {
-    true
-}
-
-Setup() {
-    source /etc/openshift-sdn/config.env
-    cluster_subnet=${OPENSHIFT_CLUSTER_SUBNET}
-
-    pid=$(docker inspect --format "{{.State.Pid}}" ${net_container})
+get_ipaddr_pid_veth() {
     network_mode=$(docker inspect --format "{{.HostConfig.NetworkMode}}" ${net_container})
     if [ "${network_mode}" == "host" ]; then
       # quit, nothing for the SDN here
       exit 0
+    elif [[ "${network_mode}" =~ container:.* ]]; then
+      # Get pod infra container
+      net_container=$(echo ${network_mode} | cut -d ":" -f 2)
     fi
     ipaddr=$(docker inspect --format "{{.NetworkSettings.IPAddress}}" ${net_container})
+    pid=$(docker inspect --format "{{.State.Pid}}" ${net_container})
     veth_host=$(get_veth_host $pid)
+}
 
+add_ovs_port() {
     brctl delif lbr0 $veth_host
-    ovs-vsctl add-port br0 ${veth_host} 
+    ovs-vsctl add-port br0 ${veth_host}
+}
+
+del_ovs_port() {
+    ovs-vsctl del-port $veth_host
+}
+
+add_ovs_flows() {
     ovs_port=$(ovs-ofctl -O OpenFlow13 dump-ports-desc br0  | grep ${veth_host} | cut -d "(" -f 1 | tr -d ' ')
 
     ovs-ofctl -O OpenFlow13 add-flow br0 "table=3,cookie=0x${ovs_port},priority=100,in_port=${ovs_port},ip,nw_src=${ipaddr},actions=load:${tenant_id}->NXM_NX_REG0[],goto_table:4"
@@ -55,23 +60,42 @@ Setup() {
     else
       ovs-ofctl -O OpenFlow13 add-flow br0 "table=6,cookie=0x${ovs_port},priority=100,ip,nw_dst=${ipaddr},reg0=${tenant_id},actions=output:${ovs_port}"
     fi
+}
 
-    add_subnet_route="ip route add ${cluster_subnet} dev eth0 proto kernel scope link src $ipaddr"
-    nsenter -n -t $pid -- $add_subnet_route
+del_ovs_flows() {
+    ovs_port=$(ovs-ofctl -O OpenFlow13 dump-ports-desc br0  | grep ${veth_host} | cut -d "(" -f 1 | tr -d ' ')
+
+    ovs-ofctl -O OpenFlow13 del-flows br0 "table=3,cookie=0x${ovs_port}/0xffffffff"
+    ovs-ofctl -O OpenFlow13 del-flows br0 "table=6,cookie=0x${ovs_port}/0xffffffff"
+}
+
+add_subnet_route() {
+    source /etc/openshift-sdn/config.env
+    local subnet_route="ip route add ${OPENSHIFT_CLUSTER_SUBNET} dev eth0 proto kernel scope link src $ipaddr"
+    nsenter -n -t $pid -- $subnet_route
+}
+
+Init() {
+    true
+}
+
+Setup() {
+    get_ipaddr_pid_veth
+    add_ovs_port
+    add_ovs_flows
+    add_subnet_route
+}
+
+Update() {
+    get_ipaddr_pid_veth
+    del_ovs_flows 
+    add_ovs_flows
 }
 
 Teardown() {
-    pid=$(docker inspect --format "{{.State.Pid}}" ${net_container})
-    network_mode=$(docker inspect --format "{{.HostConfig.NetworkMode}}" ${net_container})
-    if [ "${network_mode}" == "host" ]; then
-      # quit, nothing for the SDN here
-      exit 0
-    fi
-    veth_host=$(get_veth_host $pid)
-    ovs_port=$(ovs-ofctl -O OpenFlow13 dump-ports-desc br0  | grep ${veth_host} | cut -d "(" -f 1 | tr -d ' ')
-    ovs-vsctl del-port $veth_host
-    ovs-ofctl -O OpenFlow13 del-flows br0 "table=3,cookie=0x${ovs_port}/0xffffffff"
-    ovs-ofctl -O OpenFlow13 del-flows br0 "table=6,cookie=0x${ovs_port}/0xffffffff"
+    get_ipaddr_pid_veth
+    del_ovs_port
+    del_ovs_flows
 }
 
 Status() {
@@ -87,6 +111,10 @@ case "$action" in
 	set -x
 	lockwrap Setup
 	;;
+    update)
+	set -x
+	lockwrap Update
+	;;
     teardown)
 	set -x
 	lockwrap Teardown
@@ -98,4 +126,3 @@ case "$action" in
         echo "Bad input: $@"
         exit 1
 esac
-

--- a/pkg/ovssubnet/controller/multitenant/multitenant.go
+++ b/pkg/ovssubnet/controller/multitenant/multitenant.go
@@ -97,3 +97,9 @@ func generateServiceRule(netID uint, IP string, protocol api.ServiceProtocol, po
 		return fmt.Sprintf("table=4,priority=200,reg0=%d,%s,nw_dst=%s,tp_dst=%d,actions=output:2", netID, strings.ToLower(string(protocol)), IP, port)
 	}
 }
+
+func (c *FlowController) UpdatePod(namespace, podName, containerID string, netID uint) error {
+	out, err := exec.Command("openshift-ovs-multitenant", "update", namespace, podName, containerID, fmt.Sprint(netID)).CombinedOutput()
+	log.V(5).Infof("UpdatePod output: %s, error: %v", out, err)
+	return err
+}


### PR DESCRIPTION
- Join project networks:
    * oadm pod-network join-projects --to=[project-name] [list of projects] | --selector=[project-labels]
- Unisolate project networks:
    * oadm pod-network unisolate-projects [list of projects] | --selector=[project-labels]
- Isolate project networks: 
    * TBD (some preliminary work done)

- Persist Net namespaces with VNID=0
- Release VNID only if no namespace is using it
- openshift network plugins can handle non pod infra container
- openshift-ovs-multitenant/openshift-ovs-subnet cleanup