### PR TITLE
Service endpoint isolation

### DIFF
--- a/pkg/ovssubnet/api/types.go
+++ b/pkg/ovssubnet/api/types.go
@@ -34,6 +34,8 @@ type SubnetRegistry interface {
 	WatchServices(receiver chan<- *ServiceEvent, ready chan<- bool, startVersion <-chan string, stop <-chan bool) error
 	GetServicesForNamespace(namespace string) ([]Service, error)
 
+	GetPods() ([]Pod, string, error)
+	WatchPods(ready chan<- bool, startVersion <-chan string, stop <-chan bool) error
 	GetRunningPods(nodeName, namespace string) ([]Pod, error)
 }
 

--- a/plugins/osdn/flatsdn/flatsdn.go
+++ b/plugins/osdn/flatsdn/flatsdn.go
@@ -4,21 +4,17 @@ import (
 	"github.com/golang/glog"
 	"strings"
 
-	kclient "k8s.io/kubernetes/pkg/client/unversioned"
 	"k8s.io/kubernetes/pkg/util/exec"
 
 	"github.com/openshift/openshift-sdn/pkg/ovssubnet"
 	"github.com/openshift/openshift-sdn/plugins/osdn"
-	osclient "github.com/openshift/origin/pkg/client"
 )
 
 func NetworkPluginName() string {
 	return "redhat/openshift-ovs-subnet"
 }
 
-func Master(osClient *osclient.Client, kClient *kclient.Client, clusterNetworkCIDR string, clusterBitsPerSubnet uint, serviceNetworkCIDR string) {
-	osdnInterface := osdn.NewOsdnRegistryInterface(osClient, kClient)
-
+func Master(registry *osdn.OsdnRegistryInterface, clusterNetworkCIDR string, clusterBitsPerSubnet uint, serviceNetworkCIDR string) {
 	// get hostname from the gateway
 	output, err := exec.New().Command("uname", "-n").CombinedOutput()
 	if err != nil {
@@ -26,7 +22,7 @@ func Master(osClient *osclient.Client, kClient *kclient.Client, clusterNetworkCI
 	}
 	host := strings.TrimSpace(string(output))
 
-	kc, err := ovssubnet.NewKubeController(&osdnInterface, host, "", nil)
+	kc, err := ovssubnet.NewKubeController(registry, host, "", nil)
 	if err != nil {
 		glog.Fatalf("SDN initialization failed: %v", err)
 	}
@@ -36,9 +32,8 @@ func Master(osClient *osclient.Client, kClient *kclient.Client, clusterNetworkCI
 	}
 }
 
-func Node(osClient *osclient.Client, kClient *kclient.Client, hostname string, publicIP string, ready chan struct{}, mtu uint) {
-	osdnInterface := osdn.NewOsdnRegistryInterface(osClient, kClient)
-	kc, err := ovssubnet.NewKubeController(&osdnInterface, hostname, publicIP, ready)
+func Node(registry *osdn.OsdnRegistryInterface, hostname string, publicIP string, ready chan struct{}, mtu uint) {
+	kc, err := ovssubnet.NewKubeController(registry, hostname, publicIP, ready)
 	if err != nil {
 		glog.Fatalf("SDN initialization failed: %v", err)
 	}

--- a/plugins/osdn/osdn.go
+++ b/plugins/osdn/osdn.go
@@ -31,8 +31,8 @@ type OsdnRegistryInterface struct {
 	kClient kclient.Interface
 }
 
-func NewOsdnRegistryInterface(osClient *osclient.Client, kClient *kclient.Client) OsdnRegistryInterface {
-	return OsdnRegistryInterface{osClient, kClient}
+func NewOsdnRegistryInterface(osClient *osclient.Client, kClient *kclient.Client) *OsdnRegistryInterface {
+	return &OsdnRegistryInterface{osClient, kClient}
 }
 
 func (oi *OsdnRegistryInterface) GetSubnets() ([]osdnapi.Subnet, string, error) {


### PR DESCRIPTION
Problem: because we only handle service isolation on the source end, you can work around isolation (of both pods and services) by creating a headless service and then manually assigning it endpoints in another project

Solution 1: Use pure-iptables-based service proxying, then do isolation at the destination rather than the source. But this turns out to not work because we still have to masquerade the packets (or else the service will try to send its response directly back to the client, which will reject them because it doesn't have an open connection to the service pod IP) so the destination doesn't know the source IP.

Solution 2: Use OVS-based service proxying instead of iptables so we can carry the source VNID through the whole process. But we still need to masquerade, for the same reason as with iptables, so this can't be done without OVS conntrack support. (Though I think this is the eventual best solution.)

Solution 3: Find some other way to pass the VNID through kube-proxy... Like... maybe kube-proxy would bind its outgoing connection to a source port that had some mathematical relation to the VNID and the destination would check that? Or not.

Solution 3a: use IPv6 addresses and encode information into some of the excess bits. Except we can't use IPv6.

Solution 4: Filter the illegal endpoints out of the list passed to Proxier so we can guarantee that source-side filtering will be sufficient.

This branch implements solution 4. The origin side is at https://github.com/danwinship/origin/commits/endpoint-isolation.

The osdnapi.Pod stuff is going to conflict with Ravi's branch...

@pravisankar @dcbw 