### PR TITLE
Detect SDN setup requirement when user switches between flat and multitenant plugins

### DIFF
--- a/pkg/ovssubnet/controller/kube/bin/openshift-sdn-kube-subnet-setup.sh
+++ b/pkg/ovssubnet/controller/kube/bin/openshift-sdn-kube-subnet-setup.sh
@@ -87,6 +87,9 @@ function setup_required() {
     if ! docker_network_config check; then
         return 0
     fi
+    if ! ovs-ofctl -O OpenFlow13 dump-flows br0 | grep -q 'table=0.*arp'; then
+        return 0
+    fi
     return 1
 }
 

--- a/pkg/ovssubnet/controller/multitenant/bin/openshift-sdn-multitenant-setup.sh
+++ b/pkg/ovssubnet/controller/multitenant/bin/openshift-sdn-multitenant-setup.sh
@@ -87,6 +87,9 @@ function setup_required() {
     if ! docker_network_config check; then
         return 0
     fi
+    if ! ovs-ofctl -O OpenFlow13 dump-flows br0 | grep -q NXM_NX_TUN_IPV4; then
+        return 0
+    fi
     return 1
 }
 


### PR DESCRIPTION
This will eliminate migration script.