### PR TITLE
Don't use vxlan for local subnet communication [DO NOT MERGE]

### DIFF
--- a/pkg/netutils/common.go
+++ b/pkg/netutils/common.go
@@ -4,6 +4,8 @@ import (
 	"encoding/binary"
 	"fmt"
 	"net"
+	"os/exec"
+	"strings"
 )
 
 func IPToUint32(ip net.IP) uint32 {
@@ -40,4 +42,30 @@ func GetNodeIP(nodeName string) (string, error) {
 		return "", fmt.Errorf("Failed to obtain IP address from node name: %s", nodeName)
 	}
 	return ip.String(), nil
+}
+
+func GetNodeSubnet(nodeIP string) (*net.IPNet, error) {
+	ip := net.ParseIP(nodeIP)
+	if ip == nil {
+		return nil, fmt.Errorf("Invalid nodeIP: %s", nodeIP)
+	}
+
+	routes, err := exec.Command("ip", "route").CombinedOutput()
+	if err != nil {
+		return nil, fmt.Errorf("Could not execute 'ip route': %s", err)
+	}
+	for _, route := range strings.Split(string(routes), "\n") {
+		words := strings.Split(route, " ")
+		if len(words) == 0 || words[0] == "default" {
+			continue
+		}
+		_, network, err := net.ParseCIDR(words[0])
+		if err != nil {
+			continue
+		}
+		if network.Contains(ip) {
+			return network, nil
+		}
+	}
+	return nil, fmt.Errorf("Could not find subnet for node %s", nodeIP)
 }

--- a/pkg/netutils/common.go
+++ b/pkg/netutils/common.go
@@ -2,6 +2,7 @@ package netutils
 
 import (
 	"encoding/binary"
+	"fmt"
 	"net"
 )
 
@@ -19,4 +20,24 @@ func Uint32ToIP(u uint32) net.IP {
 func GenerateDefaultGateway(sna *net.IPNet) net.IP {
 	ip := sna.IP.To4()
 	return net.IPv4(ip[0], ip[1], ip[2], ip[3]|0x1)
+}
+
+func GetNodeIP(nodeName string) (string, error) {
+	ip := net.ParseIP(nodeName)
+	if ip == nil {
+		addrs, err := net.LookupIP(nodeName)
+		if err != nil {
+			return "", fmt.Errorf("Failed to lookup IP address for node %s: %v", nodeName, err)
+		}
+		for _, addr := range addrs {
+			if addr.String() != "127.0.0.1" {
+				ip = addr
+				break
+			}
+		}
+	}
+	if ip == nil || len(ip.String()) == 0 {
+		return "", fmt.Errorf("Failed to obtain IP address from node name: %s", nodeName)
+	}
+	return ip.String(), nil
 }

--- a/pkg/ovssubnet/common.go
+++ b/pkg/ovssubnet/common.go
@@ -70,7 +70,7 @@ func NewMultitenantController(sub api.SubnetRegistry, hostname string, selfIP st
 func NewController(sub api.SubnetRegistry, hostname string, selfIP string, ready chan struct{}) (*OvsController, error) {
 	if selfIP == "" {
 		var err error
-		selfIP, err = GetNodeIP(hostname)
+		selfIP, err = netutils.GetNodeIP(hostname)
 		if err != nil {
 			return nil, err
 		}
@@ -581,27 +581,6 @@ func (oc *OvsController) watchCluster(ready chan<- bool, start <-chan string) {
 
 func (oc *OvsController) Stop() {
 	close(oc.sig)
-}
-
-func GetNodeIP(nodeName string) (string, error) {
-	ip := net.ParseIP(nodeName)
-	if ip == nil {
-		addrs, err := net.LookupIP(nodeName)
-		if err != nil {
-			log.Errorf("Failed to lookup IP address for node %s: %v", nodeName, err)
-			return "", err
-		}
-		for _, addr := range addrs {
-			if addr.String() != "127.0.0.1" {
-				ip = addr
-				break
-			}
-		}
-	}
-	if ip == nil || len(ip.String()) == 0 {
-		return "", fmt.Errorf("Failed to obtain IP address from node name: %s", nodeName)
-	}
-	return ip.String(), nil
 }
 
 // Wait for ready signal from Watch interface for the given resource

--- a/pkg/ovssubnet/controller/multitenant/multitenant.go
+++ b/pkg/ovssubnet/controller/multitenant/multitenant.go
@@ -41,7 +41,7 @@ func (c *FlowController) Setup(localSubnetCIDR, clusterNetworkCIDR, servicesNetw
 	return nil
 }
 
-func (c *FlowController) AddOFRules(nodeIP, nodeSubnetCIDR, localIP string) error {
+func (c *FlowController) AddOFRules(nodeIP, nodeSubnetCIDR, localIP string, localNetwork *net.IPNet) error {
 	if nodeIP == localIP {
 		return nil
 	}
@@ -56,7 +56,7 @@ func (c *FlowController) AddOFRules(nodeIP, nodeSubnetCIDR, localIP string) erro
 	return e
 }
 
-func (c *FlowController) DelOFRules(nodeIP, localIP string) error {
+func (c *FlowController) DelOFRules(nodeIP, nodeSubnetCIDR, localIP string, localNetwork *net.IPNet) error {
 	if nodeIP == localIP {
 		return nil
 	}

--- a/plugins/osdn/osdn.go
+++ b/plugins/osdn/osdn.go
@@ -21,7 +21,7 @@ import (
 	"k8s.io/kubernetes/pkg/types"
 	"k8s.io/kubernetes/pkg/watch"
 
-	osdn "github.com/openshift/openshift-sdn/pkg/ovssubnet"
+	"github.com/openshift/openshift-sdn/pkg/netutils"
 	osdnapi "github.com/openshift/openshift-sdn/pkg/ovssubnet/api"
 
 	osclient "github.com/openshift/origin/pkg/client"
@@ -193,7 +193,7 @@ func (oi *OsdnRegistryInterface) GetNodes() ([]osdnapi.Node, string, error) {
 			nodeIP = node.Status.Addresses[0].Address
 		} else {
 			var err error
-			nodeIP, err = osdn.GetNodeIP(node.ObjectMeta.Name)
+			nodeIP, err = netutils.GetNodeIP(node.ObjectMeta.Name)
 			if err != nil {
 				return nil, "", err
 			}
@@ -238,7 +238,7 @@ func (oi *OsdnRegistryInterface) WatchNodes(receiver chan<- *osdnapi.NodeEvent, 
 		if len(node.Status.Addresses) > 0 {
 			nodeIP = node.Status.Addresses[0].Address
 		} else {
-			nodeIP, err = osdn.GetNodeIP(node.ObjectMeta.Name)
+			nodeIP, err = netutils.GetNodeIP(node.ObjectMeta.Name)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
For containers on other nodes on the same subnet, we can use the nodes as routers and thus forward the traffic unencapsulated.

Proof of concept: not yet supported in multitenant, because it requires more work there (we can't pass the source VNID along, so we'd have to know the VNID of every IP address on every host. Or at least every non-local IP address... Anyway, possible scaling issues...
