### PR TITLE
Fix non-multitenant pod routing

### DIFF
--- a/pkg/ovssubnet/controller/kube/bin/openshift-ovs-subnet
+++ b/pkg/ovssubnet/controller/kube/bin/openshift-ovs-subnet
@@ -76,6 +76,7 @@ Setup() {
     get_ipaddr_pid_veth
     add_ovs_port
     add_ovs_flows
+    add_subnet_route
 }
 
 Teardown() {


### PR DESCRIPTION
The non-multitenant plugin got broken as part of the changes that went with the new oadm commands. The multitenant plugin still worked fine so none of us noticed... Gotta get those automated tests working...

Fixes https://github.com/openshift/origin/issues/5152

cc @pravisankar @sdodson 