### PR TITLE
Clean up stale OVS flows correctly / don't error out of TearDown early

### DIFF
--- a/pkg/ovssubnet/controller/kube/bin/openshift-ovs-subnet
+++ b/pkg/ovssubnet/controller/kube/bin/openshift-ovs-subnet
@@ -46,7 +46,7 @@ add_ovs_port() {
 }
 
 del_ovs_port() {
-    ovs-vsctl del-port $veth_host
+    ovs-vsctl --if-exists del-port $veth_host
 }
 
 add_ovs_flows() {

--- a/pkg/ovssubnet/controller/multitenant/bin/openshift-ovs-multitenant
+++ b/pkg/ovssubnet/controller/multitenant/bin/openshift-ovs-multitenant
@@ -48,7 +48,7 @@ add_ovs_port() {
 }
 
 del_ovs_port() {
-    ovs-vsctl del-port $veth_host
+    ovs-vsctl --if-exists del-port $veth_host
 }
 
 add_ovs_flows() {


### PR DESCRIPTION
OpenFlow rules were getting left behind because the TearDown was erroring out early because it was trying to remove the veth from the bridge after the veth had already been destroyed.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1272295
@pravisankar 