### PR TITLE
Isolate docker bridge initialization to enable containerized installs

### DIFF
--- a/pkg/ovssubnet/controller/kube/bin/openshift-sdn-kube-subnet-setup.sh
+++ b/pkg/ovssubnet/controller/kube/bin/openshift-sdn-kube-subnet-setup.sh
@@ -41,10 +41,12 @@ function docker_network_config() {
 
 DOCKER_NETWORK_OPTIONS='${DOCKER_NETWORK_OPTIONS}'
 EOF
-
-		systemctl daemon-reload
-		systemctl restart docker.service
-
+		## linux bridge
+		ip link set lbr0 down || true
+		brctl delbr lbr0 || true
+		brctl addbr lbr0
+		ip addr add ${local_subnet_gateway}/${local_subnet_mask_len} dev lbr0
+		ip link set lbr0 up
 
 	    if [ ! -f /.dockerinit ]; then
 		# disable iptables for lbr0
@@ -56,6 +58,11 @@ EOF
 		modprobe br_netfilter || true
 		sysctl -w net.bridge.bridge-nf-call-iptables=0
 	    fi
+		# when using --pid=host to run docker container, systemctl inside it refuses
+		# to work because it detects that it's running in chroot. using dbus instead
+		# of systemctl is just a workaround
+		dbus-send --system --print-reply --reply-timeout=2000 --type=method_call --dest=org.freedesktop.systemd1 /org/freedesktop/systemd1 org.freedesktop.systemd1.Manager.Reload
+		dbus-send --system --print-reply --reply-timeout=2000 --type=method_call --dest=org.freedesktop.systemd1 /org/freedesktop/systemd1 org.freedesktop.systemd1.Manager.RestartUnit string:'docker.service' string:'replace'
 	    ;;
     esac
 }
@@ -63,9 +70,6 @@ EOF
 function setup_required() {
     ip=$(echo `ip a s lbr0 2>/dev/null|awk '/inet / {print $2}'`)
     if [ "$ip" != "${local_subnet_gateway}/${local_subnet_mask_len}" ]; then
-        return 0
-    fi
-    if ! docker_network_config check; then
         return 0
     fi
     if ! ovs-ofctl -O OpenFlow13 dump-flows br0 | grep -q 'table=0.*arp'; then
@@ -115,25 +119,15 @@ function setup() {
     ip link set vovsbr up
     ip link set vlinuxbr txqueuelen 0
     ip link set vovsbr txqueuelen 0
+    brctl addif lbr0 vlinuxbr
 
     ovs-vsctl del-port br0 vovsbr || true
     ovs-vsctl add-port br0 vovsbr -- set Interface vovsbr ofport_request=9
-
-    ## linux bridge
-    ip link set lbr0 down || true
-    brctl delbr lbr0 || true
-    brctl addbr lbr0
-    ip addr add ${local_subnet_gateway}/${local_subnet_mask_len} dev lbr0
-    ip link set lbr0 up
-    brctl addif lbr0 vlinuxbr
 
     # setup tun address
     ip addr add ${local_subnet_gateway}/${local_subnet_mask_len} dev ${TUN}
     ip link set ${TUN} up
     ip route add ${cluster_network_cidr} dev ${TUN} proto kernel scope link
-
-    ## docker
-    docker_network_config update
 
     # Cleanup docker0 since docker won't do it
     ip link set docker0 down || true
@@ -152,6 +146,10 @@ function setup() {
 }
 
 set +e
+if ! docker_network_config check; then
+  lockwrap docker_network_config update
+fi
+
 if ! setup_required; then
     echo "SDN setup not required."
     exit 140

--- a/pkg/ovssubnet/controller/kube/bin/openshift-sdn-kube-subnet-setup.sh
+++ b/pkg/ovssubnet/controller/kube/bin/openshift-sdn-kube-subnet-setup.sh
@@ -141,7 +141,7 @@ function setup() {
     echo "export OPENSHIFT_CLUSTER_SUBNET=${cluster_network_cidr}" >> "/etc/openshift-sdn/config.env"
 
     # delete unnecessary routes
-    delete_local_subnet_route lbr0
+    delete_local_subnet_route lbr0 || true
     delete_local_subnet_route ${TUN} || true
 }
 

--- a/pkg/ovssubnet/controller/multitenant/bin/openshift-sdn-multitenant-setup.sh
+++ b/pkg/ovssubnet/controller/multitenant/bin/openshift-sdn-multitenant-setup.sh
@@ -180,7 +180,7 @@ function setup() {
     echo "export OPENSHIFT_CLUSTER_SUBNET=${cluster_network_cidr}" >> "/etc/openshift-sdn/config.env"
 
     # delete unnecessary routes
-    delete_local_subnet_route lbr0
+    delete_local_subnet_route lbr0 || true
     delete_local_subnet_route ${TUN} || true
 }
 

--- a/pkg/ovssubnet/controller/multitenant/bin/openshift-sdn-multitenant-setup.sh
+++ b/pkg/ovssubnet/controller/multitenant/bin/openshift-sdn-multitenant-setup.sh
@@ -42,8 +42,12 @@ function docker_network_config() {
 DOCKER_NETWORK_OPTIONS='${DOCKER_NETWORK_OPTIONS}'
 EOF
 
-		systemctl daemon-reload
-		systemctl restart docker.service
+		## linux bridge
+		ip link set lbr0 down || true
+		brctl delbr lbr0 || true
+		brctl addbr lbr0
+		ip addr add ${local_subnet_gateway}/${local_subnet_mask_len} dev lbr0
+		ip link set lbr0 up
 
 	    if [ ! -f /.dockerinit ]; then
 		# disable iptables for lbr0
@@ -55,6 +59,11 @@ EOF
 		modprobe br_netfilter || true
 		sysctl -w net.bridge.bridge-nf-call-iptables=0
 	    fi
+		# when using --pid=host to run docker container, systemctl inside it refuses
+		# to work because it detects that it's running in chroot. using dbus instead
+		# of systemctl is just a workaround
+		dbus-send --system --print-reply --reply-timeout=2000 --type=method_call --dest=org.freedesktop.systemd1 /org/freedesktop/systemd1 org.freedesktop.systemd1.Manager.Reload
+		dbus-send --system --print-reply --reply-timeout=2000 --type=method_call --dest=org.freedesktop.systemd1 /org/freedesktop/systemd1 org.freedesktop.systemd1.Manager.RestartUnit string:'docker.service' string:'replace'
 	    ;;
     esac
 }
@@ -62,9 +71,6 @@ EOF
 function setup_required() {
     ip=$(echo `ip a s lbr0 2>/dev/null|awk '/inet / {print $2}'`)
     if [ "$ip" != "${local_subnet_gateway}/${local_subnet_mask_len}" ]; then
-        return 0
-    fi
-    if ! docker_network_config check; then
         return 0
     fi
     if ! ovs-ofctl -O OpenFlow13 dump-flows br0 | grep -q NXM_NX_TUN_IPV4; then
@@ -114,6 +120,7 @@ function setup() {
     ip link set vovsbr up
     ip link set vlinuxbr txqueuelen 0
     ip link set vovsbr txqueuelen 0
+    brctl addif lbr0 vlinuxbr
 
     ovs-vsctl del-port br0 vovsbr || true
     ovs-vsctl add-port br0 vovsbr -- set Interface vovsbr ofport_request=3
@@ -156,21 +163,10 @@ function setup() {
     # and with per-node vxlan ARP rules by multitenant.go
     ovs-ofctl -O OpenFlow13 add-flow br0 "table=8, priority=0, arp, actions=flood"
 
-    ## linux bridge
-    ip link set lbr0 down || true
-    brctl delbr lbr0 || true
-    brctl addbr lbr0
-    ip addr add ${local_subnet_gateway}/${local_subnet_mask_len} dev lbr0
-    ip link set lbr0 up
-    brctl addif lbr0 vlinuxbr
-
     # setup tun address
     ip addr add ${local_subnet_gateway}/${local_subnet_mask_len} dev ${TUN}
     ip link set ${TUN} up
     ip route add ${cluster_network_cidr} dev ${TUN} proto kernel scope link
-
-    ## docker
-    docker_network_config update
 
     # Cleanup docker0 since docker won't do it
     ip link set docker0 down || true
@@ -189,6 +185,10 @@ function setup() {
 }
 
 set +e
+if ! docker_network_config check; then
+  lockwrap docker_network_config update
+fi
+
 if ! setup_required; then
     echo "SDN setup not required."
     exit 140


### PR DESCRIPTION
For use in an origin-node image that's built atop openshift/origin. The systemd service that starts the node container is Restart=always and is responsible for starting the node again after docker has been restarted.