### PR TITLE
Fix multitenant flow cleanup again

### DIFF
--- a/pkg/ovssubnet/controller/multitenant/bin/openshift-ovs-multitenant
+++ b/pkg/ovssubnet/controller/multitenant/bin/openshift-ovs-multitenant
@@ -54,19 +54,17 @@ del_ovs_port() {
 add_ovs_flows() {
     ovs_port=$(ovs-ofctl -O OpenFlow13 dump-ports-desc br0  | grep ${veth_host} | cut -d "(" -f 1 | tr -d ' ')
 
-    ovs-ofctl -O OpenFlow13 add-flow br0 "table=3,cookie=0x${ovs_port},priority=100,in_port=${ovs_port},ip,nw_src=${ipaddr},actions=load:${tenant_id}->NXM_NX_REG0[],goto_table:4"
+    ovs-ofctl -O OpenFlow13 add-flow br0 "table=3,priority=100,in_port=${ovs_port},ip,nw_src=${ipaddr},actions=load:${tenant_id}->NXM_NX_REG0[],goto_table:4"
     if [ "${tenant_id}" == "0" ]; then
-      ovs-ofctl -O OpenFlow13 add-flow br0 "table=6,cookie=0x${ovs_port},priority=150,ip,nw_dst=${ipaddr},actions=output:${ovs_port}"
+      ovs-ofctl -O OpenFlow13 add-flow br0 "table=6,priority=150,ip,nw_dst=${ipaddr},actions=output:${ovs_port}"
     else
-      ovs-ofctl -O OpenFlow13 add-flow br0 "table=6,cookie=0x${ovs_port},priority=100,ip,nw_dst=${ipaddr},reg0=${tenant_id},actions=output:${ovs_port}"
+      ovs-ofctl -O OpenFlow13 add-flow br0 "table=6,priority=100,ip,nw_dst=${ipaddr},reg0=${tenant_id},actions=output:${ovs_port}"
     fi
 }
 
 del_ovs_flows() {
-    ovs_port=$(ovs-ofctl -O OpenFlow13 dump-ports-desc br0  | grep ${veth_host} | cut -d "(" -f 1 | tr -d ' ')
-
-    ovs-ofctl -O OpenFlow13 del-flows br0 "table=3,cookie=0x${ovs_port}/0xffffffff"
-    ovs-ofctl -O OpenFlow13 del-flows br0 "table=6,cookie=0x${ovs_port}/0xffffffff"
+    ovs-ofctl -O OpenFlow13 del-flows br0 "table=3,ip,nw_src=${ipaddr}"
+    ovs-ofctl -O OpenFlow13 del-flows br0 "table=6,ip,nw_dst=${ipaddr}"
 }
 
 add_subnet_route() {


### PR DESCRIPTION
Kubernetes now seems to destroy the veths before running Teardown, so it's no longer possible to find the OVS port a container was attached to, so we have to use different logic to clean up after them.

(Last time I stupidly tested against the kube plugin so didn't notice I hadn't fully fixed the multitenant plugin...)

@pravisankar 