### PR TITLE
Remove unused lookup of VNID for TearDownPod

### DIFF
--- a/plugins/osdn/multitenant/plugins.go
+++ b/plugins/osdn/multitenant/plugins.go
@@ -52,11 +52,8 @@ func (plugin *MultitenantPlugin) SetUpPod(namespace string, name string, id kube
 }
 
 func (plugin *MultitenantPlugin) TearDownPod(namespace string, name string, id kubeletTypes.DockerID) error {
-	vnid, found := plugin.OvsController.VNIDMap[namespace]
-	if !found {
-		return fmt.Errorf("Error fetching VNID for namespace: %s", namespace)
-	}
-	out, err := utilexec.New().Command(plugin.getExecutable(), tearDownCmd, namespace, name, string(id), strconv.FormatUint(uint64(vnid), 10)).CombinedOutput()
+	// The script's teardown functionality doesn't need the VNID
+	out, err := utilexec.New().Command(plugin.getExecutable(), tearDownCmd, namespace, name, string(id), "-1").CombinedOutput()
 	glog.V(5).Infof("TearDownPod 'multitenant' network plugin output: %s, %v", string(out), err)
 	return err
 }


### PR DESCRIPTION
The script doesn't care about the VNID, so we shouldn't bother
looking it up only to fail if the teardown request comes after
the master has sent the NetNamespace deleted notification.

https://bugzilla.redhat.com/show_bug.cgi?id=1277383