### PR TITLE
Shuffle things around in node start to fix a hang

### DIFF
--- a/plugins/osdn/api/types.go
+++ b/plugins/osdn/api/types.go
@@ -1,7 +1,6 @@
 package api
 
 import (
-	"github.com/openshift/origin/pkg/cmd/server/kubernetes"
 	knetwork "k8s.io/kubernetes/pkg/kubelet/network"
 )
 
@@ -85,5 +84,5 @@ type OsdnPlugin interface {
 	knetwork.NetworkPlugin
 
 	StartMaster(clusterNetworkCIDR string, clusterBitsPerSubnet uint, serviceNetworkCIDR string) error
-	StartNode(mtu uint) (kubernetes.FilteringEndpointsConfigHandler, error)
+	StartNode(mtu uint) error
 }

--- a/plugins/osdn/factory/factory.go
+++ b/plugins/osdn/factory/factory.go
@@ -8,6 +8,7 @@ import (
 	"github.com/openshift/openshift-sdn/plugins/osdn/api"
 
 	osclient "github.com/openshift/origin/pkg/client"
+	oskserver "github.com/openshift/origin/pkg/cmd/server/kubernetes"
 	kclient "k8s.io/kubernetes/pkg/client/unversioned"
 
 	"github.com/openshift/openshift-sdn/plugins/osdn/flatsdn"
@@ -15,7 +16,7 @@ import (
 )
 
 // Call by higher layers to create the plugin instance
-func NewPlugin(pluginType string, osClient *osclient.Client, kClient *kclient.Client, hostname string, selfIP string, ready chan struct{}) (api.OsdnPlugin, error) {
+func NewPlugin(pluginType string, osClient *osclient.Client, kClient *kclient.Client, hostname string, selfIP string, ready chan struct{}) (api.OsdnPlugin, oskserver.FilteringEndpointsConfigHandler, error) {
 	switch strings.ToLower(pluginType) {
 	case flatsdn.NetworkPluginName():
 		return flatsdn.CreatePlugin(osdn.NewRegistry(osClient, kClient), hostname, selfIP, ready)
@@ -23,5 +24,5 @@ func NewPlugin(pluginType string, osClient *osclient.Client, kClient *kclient.Cl
 		return multitenant.CreatePlugin(osdn.NewRegistry(osClient, kClient), hostname, selfIP, ready)
 	}
 
-	return nil, fmt.Errorf("unknown network plugin type: %v", pluginType)
+	return nil, nil, fmt.Errorf("unknown network plugin type: %v", pluginType)
 }

--- a/plugins/osdn/flatsdn/flatsdn.go
+++ b/plugins/osdn/flatsdn/flatsdn.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/openshift/openshift-sdn/plugins/osdn"
 	"github.com/openshift/openshift-sdn/plugins/osdn/api"
-	"github.com/openshift/origin/pkg/cmd/server/kubernetes"
+	oskserver "github.com/openshift/origin/pkg/cmd/server/kubernetes"
 
 	knetwork "k8s.io/kubernetes/pkg/kubelet/network"
 	kubeletTypes "k8s.io/kubernetes/pkg/kubelet/types"
@@ -20,15 +20,15 @@ func NetworkPluginName() string {
 	return "redhat/openshift-ovs-subnet"
 }
 
-func CreatePlugin(registry *osdn.Registry, hostname string, selfIP string, ready chan struct{}) (api.OsdnPlugin, error) {
+func CreatePlugin(registry *osdn.Registry, hostname string, selfIP string, ready chan struct{}) (api.OsdnPlugin, oskserver.FilteringEndpointsConfigHandler, error) {
 	fsp := &flatsdnPlugin{}
 
 	err := fsp.BaseInit(registry, NewFlowController(), fsp, hostname, selfIP, ready)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
-	return fsp, err
+	return fsp, nil, err
 }
 
 func (plugin *flatsdnPlugin) PluginStartMaster(clusterNetworkCIDR string, clusterBitsPerSubnet uint, serviceNetworkCIDR string) error {
@@ -39,12 +39,12 @@ func (plugin *flatsdnPlugin) PluginStartMaster(clusterNetworkCIDR string, cluste
 	return nil
 }
 
-func (plugin *flatsdnPlugin) PluginStartNode(mtu uint) (kubernetes.FilteringEndpointsConfigHandler, error) {
+func (plugin *flatsdnPlugin) PluginStartNode(mtu uint) error {
 	if err := plugin.SubnetStartNode(mtu); err != nil {
-		return nil, err
+		return err
 	}
 
-	return nil, nil
+	return nil
 }
 
 //-----------------------------------------------

--- a/plugins/osdn/multitenant/multitenant.go
+++ b/plugins/osdn/multitenant/multitenant.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/openshift/openshift-sdn/plugins/osdn"
 	"github.com/openshift/openshift-sdn/plugins/osdn/api"
-	"github.com/openshift/origin/pkg/cmd/server/kubernetes"
+	oskserver "github.com/openshift/origin/pkg/cmd/server/kubernetes"
 
 	knetwork "k8s.io/kubernetes/pkg/kubelet/network"
 	kubeletTypes "k8s.io/kubernetes/pkg/kubelet/types"
@@ -23,15 +23,15 @@ func NetworkPluginName() string {
 	return "redhat/openshift-ovs-multitenant"
 }
 
-func CreatePlugin(registry *osdn.Registry, hostname string, selfIP string, ready chan struct{}) (api.OsdnPlugin, error) {
+func CreatePlugin(registry *osdn.Registry, hostname string, selfIP string, ready chan struct{}) (api.OsdnPlugin, oskserver.FilteringEndpointsConfigHandler, error) {
 	mtp := &multitenantPlugin{}
 
 	err := mtp.BaseInit(registry, NewFlowController(), mtp, hostname, selfIP, ready)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
-	return mtp, err
+	return mtp, registry, err
 }
 
 func (plugin *multitenantPlugin) PluginStartMaster(clusterNetworkCIDR string, clusterBitsPerSubnet uint, serviceNetworkCIDR string) error {
@@ -46,16 +46,16 @@ func (plugin *multitenantPlugin) PluginStartMaster(clusterNetworkCIDR string, cl
 	return nil
 }
 
-func (plugin *multitenantPlugin) PluginStartNode(mtu uint) (kubernetes.FilteringEndpointsConfigHandler, error) {
+func (plugin *multitenantPlugin) PluginStartNode(mtu uint) error {
 	if err := plugin.SubnetStartNode(mtu); err != nil {
-		return nil, err
+		return err
 	}
 
 	if err := plugin.VnidStartNode(); err != nil {
-		return nil, err
+		return err
 	}
 
-	return plugin.Registry, nil
+	return nil
 }
 
 //-----------------------------------------------


### PR DESCRIPTION
See https://github.com/openshift/origin/pull/5840 (specifically https://github.com/openshift/origin/pull/5840/files#r44958452). We need to return the FilteringEndpointsConfigHandler sooner, so that StartNode() can be called as a goroutine, because StartNode() can't return until after its caller does, because of the weird way startup is currently organized.

(origin side is https://github.com/danwinship/origin/tree/osdn-update)

@dcbw 