### PR TITLE
Don't return an error if the plugin is unknown

### DIFF
--- a/plugins/osdn/factory/factory.go
+++ b/plugins/osdn/factory/factory.go
@@ -24,5 +24,5 @@ func NewPlugin(pluginType string, osClient *osclient.Client, kClient *kclient.Cl
 		return multitenant.CreatePlugin(osdn.NewRegistry(osClient, kClient), hostname, selfIP, ready)
 	}
 
-	return nil, nil, fmt.Errorf("unknown network plugin type: %v", pluginType)
+	return nil, nil, nil
 }


### PR DESCRIPTION
We need to silently accept unknown plugins in origin, so if we don't know about it, don't return an error that Origin will exit on.