### PR TITLE
Subnet allocation fixes

### DIFF
--- a/pkg/netutils/subnet_allocator_test.go
+++ b/pkg/netutils/subnet_allocator_test.go
@@ -35,6 +35,115 @@ func TestAllocateSubnet(t *testing.T) {
 	}
 }
 
+// 10.1.SSSSSSHH.HHHHHHHH
+func TestAllocateSubnetLargeHostBits(t *testing.T) {
+	sna, err := NewSubnetAllocator("10.1.0.0/16", 10, nil)
+	if err != nil {
+		t.Fatal("Failed to initialize subnet allocator: ", err)
+	}
+
+	sn, err := sna.GetNetwork()
+	if err != nil {
+		t.Fatal("Failed to get network: ", err)
+	}
+	if sn.String() != "10.1.0.0/22" {
+		t.Fatalf("Did not get expected subnet (n=%d, sn=%s)", 0, sn.String())
+	}
+	sn, err = sna.GetNetwork()
+	if err != nil {
+		t.Fatal("Failed to get network: ", err)
+	}
+	if sn.String() != "10.1.4.0/22" {
+		t.Fatalf("Did not get expected subnet (n=%d, sn=%s)", 1, sn.String())
+	}
+	sn, err = sna.GetNetwork()
+	if err != nil {
+		t.Fatal("Failed to get network: ", err)
+	}
+	if sn.String() != "10.1.8.0/22" {
+		t.Fatalf("Did not get expected subnet (n=%d, sn=%s)", 2, sn.String())
+	}
+	sn, err = sna.GetNetwork()
+	if err != nil {
+		t.Fatal("Failed to get network: ", err)
+	}
+	if sn.String() != "10.1.12.0/22" {
+		t.Fatalf("Did not get expected subnet (n=%d, sn=%s)", 3, sn.String())
+	}
+}
+
+// 10.1.SSSSSSSS.SSHHHHHH
+func TestAllocateSubnetLargeSubnetBits(t *testing.T) {
+	sna, err := NewSubnetAllocator("10.1.0.0/16", 6, nil)
+	if err != nil {
+		t.Fatal("Failed to initialize subnet allocator: ", err)
+	}
+
+	for n := 0; n < 256; n++ {
+		sn, err := sna.GetNetwork()
+		if err != nil {
+			t.Fatal("Failed to get network: ", err)
+		}
+		if sn.String() != fmt.Sprintf("10.1.%d.0/26", n) {
+			t.Fatalf("Did not get expected subnet (n=%d, sn=%s)", n, sn.String())
+		}
+	}
+
+	for n := 0; n < 256; n++ {
+		sn, err := sna.GetNetwork()
+		if err != nil {
+			t.Fatal("Failed to get network: ", err)
+		}
+		if sn.String() != fmt.Sprintf("10.1.%d.64/26", n) {
+			t.Fatalf("Did not get expected subnet (n=%d, sn=%s)", n+256, sn.String())
+		}
+	}
+
+	sn, err := sna.GetNetwork()
+	if err != nil {
+		t.Fatal("Failed to get network: ", err)
+	}
+	if sn.String() != "10.1.0.128/26" {
+		t.Fatalf("Did not get expected subnet (n=%d, sn=%s)", 512, sn.String())
+	}
+}
+
+// 10.000000SS.SSSSSSHH.HHHHHHHH
+func TestAllocateSubnetOverlapping(t *testing.T) {
+	sna, err := NewSubnetAllocator("10.0.0.0/14", 10, nil)
+	if err != nil {
+		t.Fatal("Failed to initialize subnet allocator: ", err)
+	}
+
+	for n := 0; n < 4; n++ {
+		sn, err := sna.GetNetwork()
+		if err != nil {
+			t.Fatal("Failed to get network: ", err)
+		}
+		if sn.String() != fmt.Sprintf("10.%d.0.0/22", n) {
+			t.Fatalf("Did not get expected subnet (n=%d, sn=%s)", n, sn.String())
+		}
+	}
+
+	for n := 0; n < 4; n++ {
+		sn, err := sna.GetNetwork()
+		if err != nil {
+			t.Fatal("Failed to get network: ", err)
+		}
+		if sn.String() != fmt.Sprintf("10.%d.4.0/22", n) {
+			t.Fatalf("Did not get expected subnet (n=%d, sn=%s)", n+4, sn.String())
+		}
+	}
+
+	sn, err := sna.GetNetwork()
+	if err != nil {
+		t.Fatal("Failed to get network: ", err)
+	}
+	if sn.String() != "10.0.8.0/22" {
+		t.Fatalf("Did not get expected subnet (n=%d, sn=%s)", 8, sn.String())
+	}
+}
+
 func TestAllocateSubnetInUse(t *testing.T) {
 	inUse := []string{"10.1.0.0/24", "10.1.2.0/24", "10.2.2.2/24", "Invalid"}
 	sna, err := NewSubnetAllocator("10.1.0.0/16", 8, inUse)

--- a/pkg/netutils/subnet_allocator_test.go
+++ b/pkg/netutils/subnet_allocator_test.go
@@ -15,21 +15,21 @@ func TestAllocateSubnet(t *testing.T) {
 		t.Fatal("Failed to get network: ", err)
 	}
 	if sn.String() != "10.1.0.0/24" {
-		t.Fatal("Did not get expected subnet")
+		t.Fatalf("Did not get expected subnet (n=%d, sn=%s)", 0, sn.String())
 	}
 	sn, err = sna.GetNetwork()
 	if err != nil {
 		t.Fatal("Failed to get network: ", err)
 	}
 	if sn.String() != "10.1.1.0/24" {
-		t.Fatal("Did not get expected subnet")
+		t.Fatalf("Did not get expected subnet (n=%d, sn=%s)", 1, sn.String())
 	}
 	sn, err = sna.GetNetwork()
 	if err != nil {
 		t.Fatal("Failed to get network: ", err)
 	}
 	if sn.String() != "10.1.2.0/24" {
-		t.Fatal("Did not get expected subnet")
+		t.Fatalf("Did not get expected subnet (n=%d, sn=%s)", 2, sn.String())
 	}
 }
 
@@ -45,14 +45,14 @@ func TestAllocateSubnetInUse(t *testing.T) {
 		t.Fatal("Failed to get network: ", err)
 	}
 	if sn.String() != "10.1.1.0/24" {
-		t.Fatal("Did not get expected subnet")
+		t.Fatalf("Did not get expected subnet (sn=%s)", sn.String())
 	}
 	sn, err = sna.GetNetwork()
 	if err != nil {
 		t.Fatal("Failed to get network: ", err)
 	}
 	if sn.String() != "10.1.3.0/24" {
-		t.Fatal("Did not get expected subnet")
+		t.Fatalf("Did not get expected subnet (sn=%s)", sn.String())
 	}
 }
 
@@ -67,7 +67,7 @@ func TestAllocateReleaseSubnet(t *testing.T) {
 		t.Fatal("Failed to get network: ", err)
 	}
 	if sn.String() != "10.1.0.0/24" {
-		t.Fatal("Did not get expected subnet")
+		t.Fatalf("Did not get expected subnet (sn=%s)", sn.String())
 	}
 
 	if err := sna.ReleaseNetwork(sn); err != nil {
@@ -79,7 +79,7 @@ func TestAllocateReleaseSubnet(t *testing.T) {
 		t.Fatal("Failed to get network: ", err)
 	}
 	if sn.String() != "10.1.0.0/24" {
-		t.Fatal("Did not get expected subnet")
+		t.Fatalf("Did not get expected subnet (sn=%s)", sn.String())
 	}
 }
 
@@ -94,12 +94,11 @@ func TestGenerateGateway(t *testing.T) {
 		t.Fatal("Failed to get network: ", err)
 	}
 	if sn.String() != "10.1.0.0/24" {
-		t.Fatal("Did not get expected subnet")
+		t.Fatalf("Did not get expected subnet (sn=%s)", sn.String())
 	}
 
 	gatewayIP := GenerateDefaultGateway(sn)
-	t.Log(gatewayIP)
 	if gatewayIP.String() != "10.1.0.1" {
-		t.Fatal("Did not get expected gateway IP Address")
+		t.Fatalf("Did not get expected gateway IP Address (gatewayIP=%s)", gatewayIP.String())
 	}
 }


### PR DESCRIPTION
Given ClusterNetworkCIDR "10.1.0.0/16" and HostSubnetLength 7, the current git master algorithm would allocate subnets in the order:

  - 10.1.0.0/25
  - 10.1.0.128/25
  - 10.1.1.0/25
  - 10.1.1.128/25

and then when you see a pod IP like "10.1.0.130", you have to stop and think to figure out which node it's on. Lame!

This branch fixes it so that the allocation order becomes:

  - 10.1.0.0/25
  - 10.1.1.0/25
  - 10.1.2.0/25
  - ...
  - 10.1.255.0/25
  - 10.1.0.128/25
  - 10.1.1.128/25
  - 10.1.2.128/25
  - ...

meaning that if you have fewer than 256 nodes, then every node will have a unique 3rd octet, just like with the HostSubnetLength=8 case.

Oh, and then there's also a mostly-unrelated change to registry.go that removes the redundant validation of ClusterNetwork changes so that https://github.com/openshift/origin/pull/6349 will work.

@openshift/networking 