### PR TITLE
Move FilteringEndpointsConfigHandler into openshift-sdn

### DIFF
--- a/plugins/osdn/api/types.go
+++ b/plugins/osdn/api/types.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	knetwork "k8s.io/kubernetes/pkg/kubelet/network"
+	pconfig "k8s.io/kubernetes/pkg/proxy/config"
 )
 
 type EventType string
@@ -85,4 +86,9 @@ type OsdnPlugin interface {
 
 	StartMaster(clusterNetworkCIDR string, clusterBitsPerSubnet uint, serviceNetworkCIDR string) error
 	StartNode(mtu uint) error
+}
+
+type FilteringEndpointsConfigHandler interface {
+	pconfig.EndpointsConfigHandler
+	SetBaseEndpointsHandler(base pconfig.EndpointsConfigHandler)
 }

--- a/plugins/osdn/factory/factory.go
+++ b/plugins/osdn/factory/factory.go
@@ -7,14 +7,13 @@ import (
 	"github.com/openshift/openshift-sdn/plugins/osdn/api"
 
 	osclient "github.com/openshift/origin/pkg/client"
-	oskserver "github.com/openshift/origin/pkg/cmd/server/kubernetes"
 	kclient "k8s.io/kubernetes/pkg/client/unversioned"
 
 	"github.com/openshift/openshift-sdn/plugins/osdn/ovs"
 )
 
 // Call by higher layers to create the plugin instance
-func NewPlugin(pluginType string, osClient *osclient.Client, kClient *kclient.Client, hostname string, selfIP string) (api.OsdnPlugin, oskserver.FilteringEndpointsConfigHandler, error) {
+func NewPlugin(pluginType string, osClient *osclient.Client, kClient *kclient.Client, hostname string, selfIP string) (api.OsdnPlugin, api.FilteringEndpointsConfigHandler, error) {
 	switch strings.ToLower(pluginType) {
 	case ovs.SingleTenantPluginName():
 		return ovs.CreatePlugin(osdn.NewRegistry(osClient, kClient), false, hostname, selfIP)

--- a/plugins/osdn/ovs/plugin.go
+++ b/plugins/osdn/ovs/plugin.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/openshift/openshift-sdn/plugins/osdn"
 	"github.com/openshift/openshift-sdn/plugins/osdn/api"
-	oskserver "github.com/openshift/origin/pkg/cmd/server/kubernetes"
 
 	knetwork "k8s.io/kubernetes/pkg/kubelet/network"
 	kubeletTypes "k8s.io/kubernetes/pkg/kubelet/types"
@@ -29,7 +28,7 @@ func MultiTenantPluginName() string {
 	return "redhat/openshift-ovs-multitenant"
 }
 
-func CreatePlugin(registry *osdn.Registry, multitenant bool, hostname string, selfIP string) (api.OsdnPlugin, oskserver.FilteringEndpointsConfigHandler, error) {
+func CreatePlugin(registry *osdn.Registry, multitenant bool, hostname string, selfIP string) (api.OsdnPlugin, api.FilteringEndpointsConfigHandler, error) {
 	plugin := &ovsPlugin{multitenant: multitenant}
 
 	err := plugin.BaseInit(registry, NewFlowController(multitenant), plugin, hostname, selfIP)


### PR DESCRIPTION
It's currently osdn specific anyway, plus we need it here to avoid
an import loop once some of liggitt's suggestions are taken for
origin SDN initialization ordering.