### PR TITLE
Bump node subnet wait to 30 seconds (from 10)

### DIFF
--- a/plugins/osdn/subnets.go
+++ b/plugins/osdn/subnets.go
@@ -134,8 +134,8 @@ func (oc *OvsController) SubnetStartNode(mtu uint) error {
 }
 
 func (oc *OvsController) initSelfSubnet() error {
-	// timeout: 10 secs
-	retries := 20
+	// timeout: 30 secs
+	retries := 60
 	retryInterval := 500 * time.Millisecond
 
 	var err error


### PR DESCRIPTION
The node subnet wait is run from a goroutine and will run
concurrently with the rest of kubelet setup.  But when a node
is heavily loaded kubelet setup might actually take close to
10 seconds or more before registration with the master starts.
That causes the subnet wait to time waiting for the subnet
registration which hasn't happened yet.  Bump the timeout.

https://bugzilla.redhat.com/show_bug.cgi?id=1290967