### PR TITLE
Admin commands should not depend on OVS code

### DIFF
--- a/pkg/cmd/admin/network/isolate_projects.go
+++ b/pkg/cmd/admin/network/isolate_projects.go
@@ -9,7 +9,6 @@ import (
 	kcmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
 	kerrors "k8s.io/kubernetes/pkg/util/errors"
 
-	"github.com/openshift/openshift-sdn/plugins/osdn/ovs"
 	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
 )
 
@@ -39,7 +38,7 @@ func NewCmdIsolateProjectsNetwork(commandName, fullName string, f *clientcmd.Fac
 	cmd := &cobra.Command{
 		Use:     commandName,
 		Short:   "Isolate project network",
-		Long:    fmt.Sprintf(isolateProjectsNetworkLong, ovs.MultiTenantPluginName()),
+		Long:    fmt.Sprintf(isolateProjectsNetworkLong, ovsPluginName),
 		Example: fmt.Sprintf(isolateProjectsNetworkExample, fullName),
 		Run: func(c *cobra.Command, args []string) {
 			if err := opts.Complete(f, c, args, out); err != nil {

--- a/pkg/cmd/admin/network/join_projects.go
+++ b/pkg/cmd/admin/network/join_projects.go
@@ -10,11 +10,12 @@ import (
 	kcmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
 	kerrors "k8s.io/kubernetes/pkg/util/errors"
 
-	"github.com/openshift/openshift-sdn/plugins/osdn/ovs"
 	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
 )
 
 const (
+	ovsPluginName = "redhat/openshift-ovs-multitenant"
+
 	JoinProjectsNetworkCommandName = "join-projects"
 
 	joinProjectsNetworkLong = `
@@ -42,7 +43,7 @@ func NewCmdJoinProjectsNetwork(commandName, fullName string, f *clientcmd.Factor
 	cmd := &cobra.Command{
 		Use:     commandName,
 		Short:   "Join project network",
-		Long:    fmt.Sprintf(joinProjectsNetworkLong, ovs.MultiTenantPluginName()),
+		Long:    fmt.Sprintf(joinProjectsNetworkLong, ovsPluginName),
 		Example: fmt.Sprintf(joinProjectsNetworkExample, fullName),
 		Run: func(c *cobra.Command, args []string) {
 			if err := opts.Complete(f, c, args, out); err != nil {

--- a/pkg/cmd/admin/network/make_projects_global.go
+++ b/pkg/cmd/admin/network/make_projects_global.go
@@ -9,12 +9,12 @@ import (
 	kcmdutil "k8s.io/kubernetes/pkg/kubectl/cmd/util"
 	kerrors "k8s.io/kubernetes/pkg/util/errors"
 
-	"github.com/openshift/openshift-sdn/plugins/osdn"
-	"github.com/openshift/openshift-sdn/plugins/osdn/ovs"
 	"github.com/openshift/origin/pkg/cmd/util/clientcmd"
 )
 
 const (
+	adminVNID = uint(0)
+
 	MakeGlobalProjectsNetworkCommandName = "make-projects-global"
 
 	makeGlobalProjectsNetworkLong = `
@@ -40,7 +40,7 @@ func NewCmdMakeGlobalProjectsNetwork(commandName, fullName string, f *clientcmd.
 	cmd := &cobra.Command{
 		Use:     commandName,
 		Short:   "Make project network global",
-		Long:    fmt.Sprintf(makeGlobalProjectsNetworkLong, ovs.MultiTenantPluginName()),
+		Long:    fmt.Sprintf(makeGlobalProjectsNetworkLong, ovsPluginName),
 		Example: fmt.Sprintf(makeGlobalProjectsNetworkExample, fullName),
 		Run: func(c *cobra.Command, args []string) {
 			if err := opts.Complete(f, c, args, out); err != nil {
@@ -71,7 +71,7 @@ func (m *MakeGlobalOptions) Run() error {
 
 	errList := []error{}
 	for _, project := range projects {
-		err = m.Options.CreateOrUpdateNetNamespace(project.ObjectMeta.Name, osdn.AdminVNID)
+		err = m.Options.CreateOrUpdateNetNamespace(project.ObjectMeta.Name, adminVNID)
 		if err != nil {
 			errList = append(errList, fmt.Errorf("Removing network isolation for project '%s' failed, error: %v", project.ObjectMeta.Name, err))
 		}


### PR DESCRIPTION
Admin commands are client centric, and should not take dependencies on
plugin implementations (which brings in lots of undesirable packages).
This change will enable the admin part of the origin CLI to be embedded
into oc.