### PR TITLE
Make pkg/ipcmd and pkg/ovs not panic if their binaries are missing

### DIFF
--- a/pkg/ipcmd/ipcmd.go
+++ b/pkg/ipcmd/ipcmd.go
@@ -2,23 +2,16 @@
 package ipcmd
 
 import (
+	"fmt"
 	"regexp"
 	"strings"
 
 	"github.com/openshift/openshift-sdn/pkg/exec"
 )
 
-var ipcmdPath string
 var addressRegexp *regexp.Regexp
 
 func init() {
-	var err error
-
-	ipcmdPath, err = exec.LookPath("ip")
-	if err != nil {
-		panic("ip is not installed")
-	}
-
 	addressRegexp = regexp.MustCompile("inet ([0-9.]*/[0-9]*) ")
 }
 
@@ -36,6 +29,12 @@ func NewTransaction(link string) *Transaction {
 
 func (tx *Transaction) exec(args []string) (string, error) {
 	if tx.err != nil {
+		return "", tx.err
+	}
+
+	ipcmdPath, err := exec.LookPath("ip")
+	if err != nil {
+		tx.err = fmt.Errorf("ip is not installed")
 		return "", tx.err
 	}
 

--- a/pkg/ovs/ovs_test.go
+++ b/pkg/ovs/ovs_test.go
@@ -8,17 +8,18 @@ import (
 	"github.com/openshift/openshift-sdn/pkg/exec"
 )
 
-// Using a global variable initializer ensures this runs before ovs.go's init()
-var dummy = setTestMode()
-
-func setTestMode() bool {
+func normalSetup() {
 	exec.SetTestMode()
 	exec.AddTestProgram("/usr/bin/ovs-ofctl")
 	exec.AddTestProgram("/usr/bin/ovs-vsctl")
-	return true
+}
+
+func missingSetup() {
+	exec.SetTestMode()
 }
 
 func TestTransactionSuccess(t *testing.T) {
+	normalSetup()
 	exec.AddTestResult("/usr/bin/ovs-ofctl -O OpenFlow13 add-flow br0 flow1", "", nil)
 	exec.AddTestResult("/usr/bin/ovs-ofctl -O OpenFlow13 add-flow br0 flow2", "", nil)
 
@@ -32,6 +33,7 @@ func TestTransactionSuccess(t *testing.T) {
 }
 
 func TestTransactionFailure(t *testing.T) {
+	normalSetup()
 	exec.AddTestResult("/usr/bin/ovs-ofctl -O OpenFlow13 add-flow br0 flow1", "", fmt.Errorf("Something bad happened"))
 
 	otx := NewTransaction("br0")
@@ -44,6 +46,7 @@ func TestTransactionFailure(t *testing.T) {
 }
 
 func TestDumpFlows(t *testing.T) {
+	normalSetup()
 	exec.AddTestResult("/usr/bin/ovs-ofctl -O OpenFlow13 dump-flows br0", `OFPST_FLOW reply (OF1.3) (xid=0x2):
  cookie=0x0, duration=13271.779s, table=0, n_packets=0, n_bytes=0, priority=100,ip,nw_dst=192.168.1.0/24 actions=set_field:0a:7b:e6:19:11:cf->eth_dst,output:2
  cookie=0x0, duration=13271.776s, table=0, n_packets=1, n_bytes=42, priority=100,arp,arp_tpa=192.168.1.0/24 actions=set_field:10.19.17.34->tun_dst,output:1
@@ -66,5 +69,19 @@ func TestDumpFlows(t *testing.T) {
 	}
 	if len(flows) != 7 {
 		t.Fatalf("Unexpected number of flows (%d)", len(flows))
+	}
+}
+
+func TestOVSMissing(t *testing.T) {
+	missingSetup()
+	otx := NewTransaction("br0")
+	otx.AddFlow("flow1")
+	otx.AddFlow("flow2")
+	err := otx.EndTransaction()
+	if err == nil {
+		t.Fatalf("Unexpectedly did not get error")
+	}
+	if err.Error() != "OVS is not installed" {
+		t.Fatalf("Got wrong error: %v", err)
 	}
 }


### PR DESCRIPTION
Fixes the breakage seen in https://github.com/openshift/origin/pull/6532

The openshift binary gets run as part of the tests/CI, so we can't panic if OVS is missing. But just returning an error will still cause it to exit at startup time when running normally, so that's OK. (And
it looks like nothing else caches the result of LookPath(), so we won't either; this is necessary to make it possible to test the missing-command codepaths.)

@dcbw 