### PR TITLE
Fix a bug with services in multitenant

### DIFF
--- a/plugins/osdn/ovs/controller.go
+++ b/plugins/osdn/ovs/controller.go
@@ -193,7 +193,7 @@ func (c *FlowController) Setup(localSubnetCIDR, clusterNetworkCIDR, servicesNetw
 	// Table 3; incoming from vxlan
 	otx.AddFlow("table=3, priority=200, ip, nw_dst=%s, actions=output:2", localSubnetGateway)
 	if c.multitenant {
-		otx.AddFlow("table=3, priority=100, ip, nw_dst=%s, actions=move:NXM_NX_TUN_ID[0..31]->NXM_NX_REG0[], goto_table:7", localSubnetCIDR)
+		otx.AddFlow("table=3, priority=100, ip, nw_dst=%s, actions=move:NXM_NX_TUN_ID[0..31]->NXM_NX_REG0[], goto_table:6", localSubnetCIDR)
 	} else {
 		otx.AddFlow("table=3, priority=100, ip, nw_dst=%s, actions=goto_table:9", localSubnetCIDR)
 	}


### PR DESCRIPTION
A reorganization of the rules in the danw/vxlan-filtering merge broke node -> remote-pod traffic (and also vnid-0-pod -> remote-pod traffic), which among other things meant that remote services would no longer work when referred to by service IP.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1293251
Probably also https://github.com/openshift/openshift-sdn/issues/231 and https://github.com/openshift/origin/issues/5796.

@openshift/networking 