### PR TITLE
Add a route to fix up service IP usage from the node.

### DIFF
--- a/plugins/osdn/ovs/controller.go
+++ b/plugins/osdn/ovs/controller.go
@@ -242,6 +242,7 @@ func (c *FlowController) Setup(localSubnetCIDR, clusterNetworkCIDR, servicesNetw
 	defer deleteLocalSubnetRoute(TUN, localSubnetCIDR)
 	itx.SetLink("up")
 	itx.AddRoute(clusterNetworkCIDR, "proto", "kernel", "scope", "link")
+	itx.AddRoute(servicesNetworkCIDR)
 	err = itx.EndTransaction()
 	if err != nil {
 		return err


### PR DESCRIPTION
(This was broken by the switch to iptables-based services, because the request would use the default IP rather than the tun0 IP, and then the response would come back via the wrong path and not get un-NAT-ed.)

Closes #232 

@dcbw: maybe get this into the resync too?