### PR TITLE
Ensure NodeIP doesn't overlap with the cluster network

### DIFF
--- a/plugins/osdn/common.go
+++ b/plugins/osdn/common.go
@@ -20,7 +20,7 @@ import (
 )
 
 type PluginHooks interface {
-	PluginStartMaster(clusterNetworkCIDR string, clusterBitsPerSubnet uint, serviceNetworkCIDR string) error
+	PluginStartMaster(clusterNetwork *net.IPNet, hostSubnetLength uint) error
 	PluginStartNode(mtu uint) error
 	UpdatePod(namespace string, name string, id kubetypes.DockerID) error
 }
@@ -161,7 +161,7 @@ func (oc *OvsController) StartMaster(clusterNetworkCIDR string, clusterBitsPerSu
 		return err
 	}
 
-	if err := oc.pluginHooks.PluginStartMaster(clusterNetwork.String(), clusterBitsPerSubnet, serviceNetwork.String()); err != nil {
+	if err := oc.pluginHooks.PluginStartMaster(clusterNetwork, clusterBitsPerSubnet); err != nil {
 		return fmt.Errorf("Failed to start plugin: %v", err)
 	}
 

--- a/plugins/osdn/ovs/plugin.go
+++ b/plugins/osdn/ovs/plugin.go
@@ -2,6 +2,7 @@ package ovs
 
 import (
 	"fmt"
+	"net"
 	"strconv"
 
 	"github.com/golang/glog"
@@ -44,8 +45,8 @@ func CreatePlugin(registry *osdn.Registry, multitenant bool, hostname string, se
 	}
 }
 
-func (plugin *ovsPlugin) PluginStartMaster(clusterNetworkCIDR string, clusterBitsPerSubnet uint, serviceNetworkCIDR string) error {
-	if err := plugin.SubnetStartMaster(clusterNetworkCIDR, clusterBitsPerSubnet, serviceNetworkCIDR); err != nil {
+func (plugin *ovsPlugin) PluginStartMaster(clusterNetwork *net.IPNet, hostSubnetLength uint) error {
+	if err := plugin.SubnetStartMaster(clusterNetwork, hostSubnetLength); err != nil {
 		return err
 	}
 

--- a/plugins/osdn/registry.go
+++ b/plugins/osdn/registry.go
@@ -1,6 +1,7 @@
 package osdn
 
 import (
+	"fmt"
 	"net"
 	"strconv"
 	"strings"
@@ -32,11 +33,12 @@ type Registry struct {
 	oClient          osclient.Interface
 	kClient          kclient.Interface
 	namespaceOfPodIP map[string]string
+	serviceNetwork   *net.IPNet
+	clusterNetwork   *net.IPNet
+	hostSubnetLength int
 
 	// These are only set if SetBaseEndpointsHandler() has been called
 	baseEndpointsHandler pconfig.EndpointsConfigHandler
-	serviceNetwork       *net.IPNet
-	clusterNetwork       *net.IPNet
 }
 
 func NewRegistry(osClient *osclient.Client, kClient *kclient.Client) *Registry {
@@ -259,6 +261,8 @@ func (registry *Registry) WatchNodes(receiver chan<- *osdnapi.NodeEvent, ready c
 }
 
 func (registry *Registry) WriteNetworkConfig(network string, subnetLength uint, serviceNetwork string) error {
+	var err error
+
 	cn, err := registry.oClient.ClusterNetwork().Get("default")
 	if err == nil {
 		if cn.Network == network && cn.HostSubnetLength == int(subnetLength) && cn.ServiceNetwork == serviceNetwork {
@@ -282,25 +286,58 @@ func (registry *Registry) WriteNetworkConfig(network string, subnetLength uint, 
 	return err
 }
 
-func (registry *Registry) GetClusterNetworkCIDR() (string, error) {
+func ValidateClusterNetwork(network string, hostSubnetLength int, serviceNetwork string) (*net.IPNet, int, *net.IPNet, error) {
+	_, cn, err := net.ParseCIDR(network)
+	if err != nil {
+		return nil, -1, nil, fmt.Errorf("Failed to parse ClusterNetwork CIDR %s: %v", network, err)
+	}
+
+	_, sn, err := net.ParseCIDR(serviceNetwork)
+	if err != nil {
+		return nil, -1, nil, fmt.Errorf("Failed to parse ServiceNetwork CIDR %s: %v", serviceNetwork, err)
+	}
+
+	if hostSubnetLength <= 0 || hostSubnetLength > 32 {
+		return nil, -1, nil, fmt.Errorf("Invalid HostSubnetLength %d (not between 1 and 32)", hostSubnetLength)
+	}
+	return cn, hostSubnetLength, sn, nil
+}
+
+func (registry *Registry) cacheClusterNetwork() error {
+	// don't hit up the master if we have the values already
+	if registry.clusterNetwork != nil && registry.serviceNetwork != nil {
+		return nil
+	}
+
 	cn, err := registry.oClient.ClusterNetwork().Get("default")
 	if err != nil {
-		return "", err
+		return err
 	}
-	return cn.Network, nil
+
+	registry.clusterNetwork, registry.hostSubnetLength, registry.serviceNetwork, err = ValidateClusterNetwork(cn.Network, cn.HostSubnetLength, cn.ServiceNetwork)
+
+	return err
+}
+
+func (registry *Registry) GetClusterNetwork() (*net.IPNet, error) {
+	if err := registry.cacheClusterNetwork(); err != nil {
+		return nil, err
+	}
+	return registry.clusterNetwork, nil
 }
 
 func (registry *Registry) GetHostSubnetLength() (int, error) {
-	cn, err := registry.oClient.ClusterNetwork().Get("default")
-	if err != nil {
+	if err := registry.cacheClusterNetwork(); err != nil {
 		return -1, err
 	}
-	return cn.HostSubnetLength, nil
+	return registry.hostSubnetLength, nil
 }
 
-func (registry *Registry) GetServicesNetworkCIDR() (string, error) {
-	cn, err := registry.oClient.ClusterNetwork().Get("default")
-	return cn.ServiceNetwork, err
+func (registry *Registry) GetServicesNetwork() (*net.IPNet, error) {
+	if err := registry.cacheClusterNetwork(); err != nil {
+		return nil, err
+	}
+	return registry.serviceNetwork, nil
 }
 
 func (registry *Registry) GetNamespaces() ([]string, string, error) {
@@ -606,17 +643,20 @@ func getEvent(eventQueue *oscache.EventQueue, startVersion uint64, checkConditio
 // FilteringEndpointsConfigHandler implementation
 func (registry *Registry) SetBaseEndpointsHandler(base pconfig.EndpointsConfigHandler) {
 	registry.baseEndpointsHandler = base
-
-	cn, err := registry.oClient.ClusterNetwork().Get("default")
-	if err != nil {
-		// "can't happen"; StartNode() will already have ensured that there's no error
-		log.Fatalf("Failed to get ClusterNetwork: %v", err)
-	}
-	_, registry.clusterNetwork, _ = net.ParseCIDR(cn.Network)
-	_, registry.serviceNetwork, _ = net.ParseCIDR(cn.ServiceNetwork)
 }
 
 func (registry *Registry) OnEndpointsUpdate(allEndpoints []kapi.Endpoints) {
+	clusterNetwork, err := registry.GetClusterNetwork()
+	if err != nil {
+		log.Warningf("Error fetching cluster network: %v", err)
+		return
+	}
+	serviceNetwork, err := registry.GetServicesNetwork()
+	if err != nil {
+		log.Warningf("Error fetching service network: %v", err)
+		return
+	}
+
 	filteredEndpoints := make([]kapi.Endpoints, 0, len(allEndpoints))
 EndpointLoop:
 	for _, ep := range allEndpoints {
@@ -624,11 +664,11 @@ EndpointLoop:
 		for _, ss := range ep.Subsets {
 			for _, addr := range ss.Addresses {
 				IP := net.ParseIP(addr.IP)
-				if registry.serviceNetwork.Contains(IP) {
+				if serviceNetwork.Contains(IP) {
 					log.Warningf("Service '%s' in namespace '%s' has an Endpoint inside the service network (%s)", ep.ObjectMeta.Name, ns, addr.IP)
 					continue EndpointLoop
 				}
-				if registry.clusterNetwork.Contains(IP) {
+				if clusterNetwork.Contains(IP) {
 					podNamespace, ok := registry.namespaceOfPodIP[addr.IP]
 					if !ok {
 						log.Warningf("Service '%s' in namespace '%s' has an Endpoint pointing to non-existent pod (%s)", ep.ObjectMeta.Name, ns, addr.IP)

--- a/plugins/osdn/subnets.go
+++ b/plugins/osdn/subnets.go
@@ -11,7 +11,7 @@ import (
 	"github.com/openshift/openshift-sdn/plugins/osdn/api"
 )
 
-func (oc *OvsController) SubnetStartMaster(clusterNetworkCIDR string, clusterBitsPerSubnet uint, serviceNetworkCIDR string) error {
+func (oc *OvsController) SubnetStartMaster(clusterNetwork *net.IPNet, hostSubnetLength uint) error {
 	subrange := make([]string, 0)
 	subnets, _, err := oc.Registry.GetSubnets()
 	if err != nil {
@@ -22,7 +22,7 @@ func (oc *OvsController) SubnetStartMaster(clusterNetworkCIDR string, clusterBit
 		subrange = append(subrange, sub.SubnetCIDR)
 	}
 
-	oc.subnetAllocator, err = netutils.NewSubnetAllocator(clusterNetworkCIDR, clusterBitsPerSubnet, subrange)
+	oc.subnetAllocator, err = netutils.NewSubnetAllocator(clusterNetwork.String(), hostSubnetLength, subrange)
 	if err != nil {
 		return err
 	}

--- a/plugins/osdn/subnets.go
+++ b/plugins/osdn/subnets.go
@@ -103,17 +103,17 @@ func (oc *OvsController) SubnetStartNode(mtu uint) (bool, error) {
 	}
 
 	// Assume we are working with IPv4
-	clusterNetworkCIDR, err := oc.Registry.GetClusterNetworkCIDR()
+	clusterNetwork, err := oc.Registry.GetClusterNetwork()
 	if err != nil {
 		log.Errorf("Failed to obtain ClusterNetwork: %v", err)
 		return false, err
 	}
-	servicesNetworkCIDR, err := oc.Registry.GetServicesNetworkCIDR()
+	servicesNetwork, err := oc.Registry.GetServicesNetwork()
 	if err != nil {
 		log.Errorf("Failed to obtain ServicesNetwork: %v", err)
 		return false, err
 	}
-	networkChanged, err := oc.flowController.Setup(oc.localSubnet.SubnetCIDR, clusterNetworkCIDR, servicesNetworkCIDR, mtu)
+	networkChanged, err := oc.flowController.Setup(oc.localSubnet.SubnetCIDR, clusterNetwork.String(), servicesNetwork.String(), mtu)
 	if err != nil {
 		return false, err
 	}


### PR DESCRIPTION
If a HostSubnet is edited or the node's IP address is changed such
that the NodeIP is contained within its own SubnetCIDR, a routing loop
will be created in the OVS bridge and cause a kernel panic by
exhausing kernel stack space.

Prevent the cluster from starting when this happens by ensuring that
the NodeIP is not contained within the cluster network CIDR.

https://bugzilla.redhat.com/show_bug.cgi?id=1295486