### PR TITLE
Don't crash on endpoints with invalid/empty IP addresses

### DIFF
--- a/plugins/osdn/registry.go
+++ b/plugins/osdn/registry.go
@@ -621,6 +621,10 @@ EndpointLoop:
 		for _, ss := range ep.Subsets {
 			for _, addr := range ss.Addresses {
 				IP := net.ParseIP(addr.IP)
+				if IP == nil {
+					log.Warningf("Service %q in namespace %q has an Endpoint with invalid IP address %q", ep.ObjectMeta.Name, ns, addr.IP)
+					continue EndpointLoop
+				}
 				if registry.serviceNetwork.Contains(IP) {
 					log.Warningf("Service '%s' in namespace '%s' has an Endpoint inside the service network (%s)", ep.ObjectMeta.Name, ns, addr.IP)
 					continue EndpointLoop


### PR DESCRIPTION
Prevents https://bugzilla.redhat.com/show_bug.cgi?id=1298942. Not exactly sure why there is an invalid endpoint, but apparently it only happens while something is being restarted. Anyway, the log message may help figure out what's actually happening.

@openshift/networking 