### PR TITLE
Crash in the right place if the ClusterNetwork record can't be read

### DIFF
--- a/plugins/osdn/factory/factory.go
+++ b/plugins/osdn/factory/factory.go
@@ -12,14 +12,28 @@ import (
 	"github.com/openshift/openshift-sdn/plugins/osdn/ovs"
 )
 
-// Call by higher layers to create the plugin instance
-func NewPlugin(pluginType string, osClient *osclient.Client, kClient *kclient.Client, hostname string, selfIP string) (api.OsdnPlugin, api.FilteringEndpointsConfigHandler, error) {
+func newPlugin(pluginType string, isMaster bool, osClient *osclient.Client, kClient *kclient.Client, hostname string, selfIP string) (api.OsdnPlugin, api.FilteringEndpointsConfigHandler, error) {
+	registry, err := osdn.NewRegistry(isMaster, osClient, kClient)
+	if err != nil {
+		return nil, nil, err
+	}
+
 	switch strings.ToLower(pluginType) {
 	case ovs.SingleTenantPluginName():
-		return ovs.CreatePlugin(osdn.NewRegistry(osClient, kClient), false, hostname, selfIP)
+		return ovs.CreatePlugin(registry, false, hostname, selfIP)
 	case ovs.MultiTenantPluginName():
-		return ovs.CreatePlugin(osdn.NewRegistry(osClient, kClient), true, hostname, selfIP)
+		return ovs.CreatePlugin(registry, true, hostname, selfIP)
 	}
 
 	return nil, nil, nil
+}
+
+// Call by higher layers to create the plugin instance
+func NewMasterPlugin(pluginType string, osClient *osclient.Client, kClient *kclient.Client) (api.OsdnPlugin, api.FilteringEndpointsConfigHandler, error) {
+	return newPlugin(pluginType, true, osClient, kClient, "", "")
+}
+
+// Call by higher layers to create the plugin instance
+func NewClientPlugin(pluginType string, osClient *osclient.Client, kClient *kclient.Client, hostname string, selfIP string) (api.OsdnPlugin, api.FilteringEndpointsConfigHandler, error) {
+	return newPlugin(pluginType, false, osClient, kClient, hostname, selfIP)
 }

--- a/plugins/osdn/registry.go
+++ b/plugins/osdn/registry.go
@@ -1,6 +1,7 @@
 package osdn
 
 import (
+	"fmt"
 	"net"
 	"strconv"
 	"strings"
@@ -38,22 +39,33 @@ type Registry struct {
 	namespaceOfPodIP     map[string]string
 }
 
-func NewRegistry(osClient *osclient.Client, kClient *kclient.Client) *Registry {
+func NewRegistry(isMaster bool, osClient *osclient.Client, kClient *kclient.Client) (*Registry, error) {
 	var clusterNetwork, serviceNetwork *net.IPNet
-	cn, err := osClient.ClusterNetwork().Get("default")
-	if err == nil {
-		_, clusterNetwork, _ = net.ParseCIDR(cn.Network)
-		_, serviceNetwork, _ = net.ParseCIDR(cn.ServiceNetwork)
+	var namespaceMap map[string]string
+
+	if !isMaster {
+		cn, err := osClient.ClusterNetwork().Get("default")
+		if err != nil {
+			return nil, fmt.Errorf("Could not get default ClusterNetwork record: %v", err)
+		}
+		_, clusterNetwork, err = net.ParseCIDR(cn.Network)
+		if err != nil {
+			return nil, fmt.Errorf("Could not parse ClusterNetwork.Network value %q: %v", cn.Network, err)
+		}
+		_, serviceNetwork, err = net.ParseCIDR(cn.ServiceNetwork)
+		if err != nil {
+			return nil, fmt.Errorf("Could not parse ClusterNetwork.ServiceNetwork value %q: %v", cn.ServiceNetwork, err)
+		}
+		namespaceMap = make(map[string]string)
 	}
-	// else the same error will occur again later and be reported
 
 	return &Registry{
 		oClient:          osClient,
 		kClient:          kClient,
 		serviceNetwork:   serviceNetwork,
 		clusterNetwork:   clusterNetwork,
-		namespaceOfPodIP: make(map[string]string),
-	}
+		namespaceOfPodIP: namespaceMap,
+	}, nil
 }
 
 func (registry *Registry) GetSubnets() ([]osdnapi.Subnet, string, error) {

--- a/plugins/osdn/registry.go
+++ b/plugins/osdn/registry.go
@@ -621,10 +621,6 @@ EndpointLoop:
 		for _, ss := range ep.Subsets {
 			for _, addr := range ss.Addresses {
 				IP := net.ParseIP(addr.IP)
-				if IP == nil {
-					log.Warningf("Service %q in namespace %q has an Endpoint with invalid IP address %q", ep.ObjectMeta.Name, ns, addr.IP)
-					continue EndpointLoop
-				}
 				if registry.serviceNetwork.Contains(IP) {
 					log.Warningf("Service '%s' in namespace '%s' has an Endpoint inside the service network (%s)", ep.ObjectMeta.Name, ns, addr.IP)
 					continue EndpointLoop


### PR DESCRIPTION
This reverts #247 as it turns out that it wasn't actually "IP" that was nil there, it was registry.serviceNetwork.

This new version requires origin changes too, because when creating the plugin, we now need to know whether we're the master or a node.

Not tested yet, so don't merge it. Waiting to hear from Jeremy on https://bugzilla.redhat.com/show_bug.cgi?id=1298942