### PR TITLE
endpoints nil crash fix (this time for sure!)

### DIFF
--- a/plugins/osdn/factory/factory.go
+++ b/plugins/osdn/factory/factory.go
@@ -12,28 +12,14 @@ import (
 	"github.com/openshift/openshift-sdn/plugins/osdn/ovs"
 )
 
-func newPlugin(pluginType string, isMaster bool, osClient *osclient.Client, kClient *kclient.Client, hostname string, selfIP string) (api.OsdnPlugin, api.FilteringEndpointsConfigHandler, error) {
-	registry, err := osdn.NewRegistry(isMaster, osClient, kClient)
-	if err != nil {
-		return nil, nil, err
-	}
-
+// Call by higher layers to create the plugin instance
+func NewPlugin(pluginType string, osClient *osclient.Client, kClient *kclient.Client, hostname string, selfIP string) (api.OsdnPlugin, api.FilteringEndpointsConfigHandler, error) {
 	switch strings.ToLower(pluginType) {
 	case ovs.SingleTenantPluginName():
-		return ovs.CreatePlugin(registry, false, hostname, selfIP)
+		return ovs.CreatePlugin(osdn.NewRegistry(osClient, kClient), false, hostname, selfIP)
 	case ovs.MultiTenantPluginName():
-		return ovs.CreatePlugin(registry, true, hostname, selfIP)
+		return ovs.CreatePlugin(osdn.NewRegistry(osClient, kClient), true, hostname, selfIP)
 	}
 
 	return nil, nil, nil
-}
-
-// Call by higher layers to create the plugin instance
-func NewMasterPlugin(pluginType string, osClient *osclient.Client, kClient *kclient.Client) (api.OsdnPlugin, api.FilteringEndpointsConfigHandler, error) {
-	return newPlugin(pluginType, true, osClient, kClient, "", "")
-}
-
-// Call by higher layers to create the plugin instance
-func NewClientPlugin(pluginType string, osClient *osclient.Client, kClient *kclient.Client, hostname string, selfIP string) (api.OsdnPlugin, api.FilteringEndpointsConfigHandler, error) {
-	return newPlugin(pluginType, false, osClient, kClient, hostname, selfIP)
 }


### PR DESCRIPTION
Already tested in origin; jenkins and travis pass.

The origin node startup code calls `StartSDN()` followed by `StartProxy()`. `StartSDN()` calls `oc.StartNode()`, which depends on `ClusterNetwork.Get("default")` returning non-nil (via `registry.GetClusterNetworkCIDR()`), so when `StartProxy()` calls `SetBaseEndpointsHandler()`, we know it will succeed.

(Note that most of this patch is just reverting #248.)

@dcbw PTAL