### PR TITLE
Ensure bridge-nf-call-iptables is always disabled on startup

### DIFF
--- a/plugins/osdn/api/types.go
+++ b/plugins/osdn/api/types.go
@@ -86,6 +86,8 @@ type OsdnPlugin interface {
 
 	StartMaster(clusterNetworkCIDR string, clusterBitsPerSubnet uint, serviceNetworkCIDR string) error
 	StartNode(mtu uint) error
+
+	NodeInitialized()
 }
 
 type FilteringEndpointsConfigHandler interface {

--- a/plugins/osdn/common.go
+++ b/plugins/osdn/common.go
@@ -16,6 +16,7 @@ import (
 	kerrors "k8s.io/kubernetes/pkg/util/errors"
 	kexec "k8s.io/kubernetes/pkg/util/exec"
 	"k8s.io/kubernetes/pkg/util/iptables"
+	"k8s.io/kubernetes/pkg/util/sysctl"
 )
 
 type PluginHooks interface {
@@ -217,6 +218,19 @@ func (oc *OvsController) StartNode(mtu uint) error {
 	oc.markPodNetworkReady()
 
 	return nil
+}
+
+func (oc *OvsController) NodeInitialized() {
+	// Disable iptables for linux bridges (and in particular lbr0), ignoring errors.
+	// (This has to have been performed in advance for docker-in-docker deployments,
+	// since this will fail there).
+	_, _ = kexec.New().Command("modprobe", "br_netfilter").CombinedOutput()
+	err := sysctl.SetSysctl("net/bridge/bridge-nf-call-iptables", 0)
+	if err != nil {
+		log.Warningf("Could not set net.bridge.bridge-nf-call-iptables sysctl: %s", err)
+	} else {
+		log.V(5).Infof("[SDN setup] set net.bridge.bridge-nf-call-iptables to 0")
+	}
 }
 
 func (oc *OvsController) markPodNetworkReady() {

--- a/plugins/osdn/ovs/controller.go
+++ b/plugins/osdn/ovs/controller.go
@@ -6,7 +6,6 @@ import (
 	"github.com/golang/glog"
 	"io/ioutil"
 	"net"
-	"os/exec"
 	"strings"
 	"time"
 
@@ -265,17 +264,6 @@ func (c *FlowController) Setup(localSubnetCIDR, clusterNetworkCIDR, servicesNetw
 	itx.DeleteLink()
 	itx.IgnoreError()
 	_ = itx.EndTransaction()
-
-	// Disable iptables for linux bridges (and in particular lbr0), ignoring errors.
-	// (This has to have been performed in advance for docker-in-docker deployments,
-	// since this will fail there).
-	_, _ = exec.Command("modprobe", "br_netfilter").CombinedOutput()
-	err = sysctl.SetSysctl("net/bridge/bridge-nf-call-iptables", 0)
-	if err != nil {
-		glog.Warningf("Could not set net.bridge.bridge-nf-call-iptables sysctl: %s", err)
-	} else {
-		glog.V(5).Infof("[SDN setup] set net.bridge.bridge-nf-call-iptables to 0")
-	}
 
 	// Enable IP forwarding for ipv4 packets
 	err = sysctl.SetSysctl("net/ipv4/ip_forward", 1)


### PR DESCRIPTION
The Kubernetes proxy and external entities could set bridge-nf-call-iptables
to 1 so we need to ensure it's still 0 after the node starts up.  In
particular the Kube proxy runs after SDN setup (because it relies on the
endpoint filters that the SDN can provide) so there's no better way to
ensure that bridge-nf-call-iptables stays 0 than a goroutine and loop.