### PR TITLE
Put the network-already-set-up check in the right place

### DIFF
--- a/plugins/osdn/ovs/controller.go
+++ b/plugins/osdn/ovs/controller.go
@@ -117,6 +117,11 @@ func (c *FlowController) Setup(localSubnetCIDR, clusterNetworkCIDR, servicesNetw
 	glog.V(5).Infof("[SDN setup] node pod subnet %s gateway %s", ipnet.String(), localSubnetGateway)
 
 	gwCIDR := fmt.Sprintf("%s/%d", localSubnetGateway, localSubnetMaskLength)
+	if alreadySetUp(c.multitenant, gwCIDR) {
+		glog.V(5).Infof("[SDN setup] no SDN setup required")
+		return nil
+	}
+	glog.V(5).Infof("[SDN setup] full SDN setup required")
 
 	itx := ipcmd.NewTransaction(LBR)
 	itx.SetLink("down")
@@ -141,13 +146,6 @@ func (c *FlowController) Setup(localSubnetCIDR, clusterNetworkCIDR, servicesNetw
 	} else {
 		glog.V(5).Infof("[SDN setup] docker setup success:\n%s", out)
 	}
-
-	if alreadySetUp(c.multitenant, gwCIDR) {
-		glog.V(5).Infof("[SDN setup] no SDN setup required")
-		return nil
-	}
-
-	glog.V(5).Infof("[SDN setup] full SDN setup required")
 
 	config := fmt.Sprintf("export OPENSHIFT_CLUSTER_SUBNET=%s", clusterNetworkCIDR)
 	err = ioutil.WriteFile("/run/openshift-sdn/config.env", []byte(config), 0644)


### PR DESCRIPTION
This ended up in the wrong place after one of the rewrites/rebases. We should check if everything is already set up correctly *before* forcibly recreating lbr0.

This didn't matter until #249 landed, because alreadySetUp() was always returning false. But now, if nothing has changed; lbr0 gets recreated, but then alreadySetUp() returns true before we re-add vlinuxbr to it, so non-OpenShift containers would be broken.

@dcbw PTAL