### PR TITLE
OVS rule updates for ARP bugs, etc

### DIFF
--- a/plugins/osdn/ovs/bin/openshift-sdn-ovs
+++ b/plugins/osdn/ovs/bin/openshift-sdn-ovs
@@ -53,23 +53,22 @@ del_ovs_port() {
 }
 
 add_ovs_flows() {
-    ovs_port=$(ovs-ofctl -O OpenFlow13 dump-ports-desc br0  | grep ${veth_host} | cut -d "(" -f 1 | tr -d ' ')
+    ovs_port=$(ovs-vsctl get Interface ${veth_host} ofport)
 
-    case $tenant_id in
-	-1) # single-tenant plugin
-	    ovs-ofctl -O OpenFlow13 add-flow br0 "table=4,priority=100,in_port=${ovs_port},ip,nw_src=${ipaddr},actions=goto_table:6"
-	    ;;
+    # from container
+    ovs-ofctl -O OpenFlow13 add-flow br0 "table=2, priority=100, in_port=${ovs_port}, arp, nw_src=${ipaddr}, actions=load:${tenant_id}->NXM_NX_REG0[], goto_table:5"
+    ovs-ofctl -O OpenFlow13 add-flow br0 "table=2, priority=100, in_port=${ovs_port}, ip, nw_src=${ipaddr}, actions=load:${tenant_id}->NXM_NX_REG0[], goto_table:3"
 
-	0)  # multi-tenant plugin, admin namespace
-	    ovs-ofctl -O OpenFlow13 add-flow br0 "table=4,priority=100,in_port=${ovs_port},ip,nw_src=${ipaddr},actions=load:${tenant_id}->NXM_NX_REG0[],goto_table:5"
-	    ovs-ofctl -O OpenFlow13 add-flow br0 "table=7,priority=150,ip,nw_dst=${ipaddr},actions=output:${ovs_port}"
-	    ;;
+    # arp request/response to container (not isolated)
+    ovs-ofctl -O OpenFlow13 add-flow br0 "table=6, priority=100, arp, nw_dst=${ipaddr}, actions=output:${ovs_port}"
 
-	*)  # multi-tenant plugin, normal namespace
-	    ovs-ofctl -O OpenFlow13 add-flow br0 "table=4,priority=100,in_port=${ovs_port},ip,nw_src=${ipaddr},actions=load:${tenant_id}->NXM_NX_REG0[],goto_table:5"
-	    ovs-ofctl -O OpenFlow13 add-flow br0 "table=7,priority=100,ip,nw_dst=${ipaddr},reg0=${tenant_id},actions=output:${ovs_port}"
-	    ;;
-    esac
+    # IP to container
+    if [ $tenant_id = "0" ]; then
+	ovs-ofctl -O OpenFlow13 add-flow br0 "table=7, priority=100, ip, nw_dst=${ipaddr}, actions=output:${ovs_port}"
+    else
+	ovs-ofctl -O OpenFlow13 add-flow br0 "table=7, priority=100, reg0=0, ip, nw_dst=${ipaddr}, actions=output:${ovs_port}"
+	ovs-ofctl -O OpenFlow13 add-flow br0 "table=7, priority=100, reg0=${tenant_id}, ip, nw_dst=${ipaddr}, actions=output:${ovs_port}"
+    fi
 }
 
 del_ovs_flows() {

--- a/plugins/osdn/ovs/bin/openshift-sdn-ovs
+++ b/plugins/osdn/ovs/bin/openshift-sdn-ovs
@@ -25,6 +25,12 @@ get_veth_host() {
     ip link show | sed -ne "s/^$veth_ifindex: \([^:@]*\).*/\1/p"
 }
 
+get_container_mac() {
+    local pid=$1
+
+    nsenter -n -t $pid -- ip link show dev eth0 | sed -n -e 's/.*link.ether \([^ ]*\).*/\1/p'
+}
+
 get_ipaddr_pid_veth() {
     network_mode=$(docker inspect --format "{{.HostConfig.NetworkMode}}" ${net_container})
     if [ "${network_mode}" == "host" ]; then
@@ -37,6 +43,7 @@ get_ipaddr_pid_veth() {
     ipaddr=$(docker inspect --format "{{.NetworkSettings.IPAddress}}" ${net_container})
     pid=$(docker inspect --format "{{.State.Pid}}" ${net_container})
     veth_host=$(get_veth_host $pid)
+    macaddr=$(get_container_mac $pid)
 }
 
 add_ovs_port() {
@@ -56,7 +63,7 @@ add_ovs_flows() {
     ovs_port=$(ovs-vsctl get Interface ${veth_host} ofport)
 
     # from container
-    ovs-ofctl -O OpenFlow13 add-flow br0 "table=2, priority=100, in_port=${ovs_port}, arp, nw_src=${ipaddr}, actions=load:${tenant_id}->NXM_NX_REG0[], goto_table:5"
+    ovs-ofctl -O OpenFlow13 add-flow br0 "table=2, priority=100, in_port=${ovs_port}, arp, nw_src=${ipaddr}, arp_sha=${macaddr}, actions=load:${tenant_id}->NXM_NX_REG0[], goto_table:5"
     ovs-ofctl -O OpenFlow13 add-flow br0 "table=2, priority=100, in_port=${ovs_port}, ip, nw_src=${ipaddr}, actions=load:${tenant_id}->NXM_NX_REG0[], goto_table:3"
 
     # arp request/response to container (not isolated)

--- a/plugins/osdn/ovs/plugin.go
+++ b/plugins/osdn/ovs/plugin.go
@@ -120,7 +120,7 @@ func (plugin *ovsPlugin) getVNID(namespace string) (string, error) {
 		return strconv.FormatUint(uint64(vnid), 10), nil
 	}
 
-	return "-1", nil
+	return "0", nil
 }
 
 func (plugin *ovsPlugin) SetUpPod(namespace string, name string, id kubeletTypes.DockerID) error {


### PR DESCRIPTION
It turns out we should never have switched to using "learn" rather than hardcoding all the mappings, because learning can only work correctly if you're willing to flood packets when you don't have a mapping. We do this for ARP packets, but not for IP packets, because that could violate isolation. But this means that if our mapping times out before a container ARP cache does, then we'll stop being able to deliver their packets. (This won't happen if the two machines are in regular communication, because OVS will keep bumping up the timeout in that case. It only happens if they talk, and then a long period of time goes by with no communication [but not *too* long], and then they try to talk again.)

Also adds some more sanity-checking to the rules to prevent spoofed packets.

Closes #231 
@openshift/networking 