### PR TITLE
Fix up pod network connectivity at startup

### DIFF
--- a/plugins/osdn/ovs/bin/openshift-sdn-ovs
+++ b/plugins/osdn/ovs/bin/openshift-sdn-ovs
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -e
+set -ex
 
 lock_file=/var/lock/openshift-sdn.lock
 
@@ -80,10 +80,6 @@ add_subnet_route() {
     nsenter -n -t $pid -- $subnet_route
 }
 
-Init() {
-    true
-}
-
 Setup() {
     get_ipaddr_pid_veth
     add_ovs_port
@@ -103,29 +99,15 @@ Teardown() {
     del_ovs_flows
 }
 
-Status() {
-    # do nothing, empty output will default to address as picked by docker
-    true
-}
-
 case "$action" in
-    init)
-	lockwrap Init
-	;;
     setup)
-	set -x
 	lockwrap Setup
 	;;
     update)
-	set -x
 	lockwrap Update
 	;;
     teardown)
-	set -x
 	lockwrap Teardown
-	;;
-    status)
-	lockwrap Status
 	;;
     *)
         echo "Bad input: $@"

--- a/plugins/osdn/ovs/bin/openshift-sdn-ovs
+++ b/plugins/osdn/ovs/bin/openshift-sdn-ovs
@@ -44,6 +44,10 @@ add_ovs_port() {
     ovs-vsctl add-port br0 ${veth_host}
 }
 
+ensure_ovs_port() {
+    ovs-vsctl --may-exist add-port br0 ${veth_host}
+}
+
 del_ovs_port() {
     ovs-vsctl --if-exists del-port $veth_host
 }
@@ -75,8 +79,12 @@ del_ovs_flows() {
 }
 
 add_subnet_route() {
-    local subnet_route="ip route add ${OPENSHIFT_CLUSTER_SUBNET} dev eth0 proto kernel scope link src $ipaddr"
-    nsenter -n -t $pid -- $subnet_route
+    nsenter -n -t $pid -- ip route add $OPENSHIFT_CLUSTER_SUBNET dev eth0 proto kernel scope link src $ipaddr
+}
+
+ensure_subnet_route() {
+    nsenter -n -t $pid -- ip route del $OPENSHIFT_CLUSTER_SUBNET dev eth0 || true
+    add_subnet_route
 }
 
 run() {
@@ -91,8 +99,10 @@ run() {
 	    ;;
 
 	update)
+	    ensure_ovs_port
 	    del_ovs_flows
 	    add_ovs_flows
+	    ensure_subnet_route
 	    ;;
 
 	teardown)

--- a/plugins/osdn/ovs/bin/openshift-sdn-ovs
+++ b/plugins/osdn/ovs/bin/openshift-sdn-ovs
@@ -75,41 +75,35 @@ del_ovs_flows() {
 }
 
 add_subnet_route() {
-    source /run/openshift-sdn/config.env
     local subnet_route="ip route add ${OPENSHIFT_CLUSTER_SUBNET} dev eth0 proto kernel scope link src $ipaddr"
     nsenter -n -t $pid -- $subnet_route
 }
 
-Setup() {
+run() {
     get_ipaddr_pid_veth
-    add_ovs_port
-    add_ovs_flows
-    add_subnet_route
+    source /run/openshift-sdn/config.env
+
+    case "$action" in
+	setup)
+	    add_ovs_port
+	    add_ovs_flows
+	    add_subnet_route
+	    ;;
+
+	update)
+	    del_ovs_flows
+	    add_ovs_flows
+	    ;;
+
+	teardown)
+	    del_ovs_port
+	    del_ovs_flows
+	    ;;
+
+	*)
+            echo "Bad input: $@"
+            exit 1
+    esac
 }
 
-Update() {
-    get_ipaddr_pid_veth
-    del_ovs_flows
-    add_ovs_flows
-}
-
-Teardown() {
-    get_ipaddr_pid_veth
-    del_ovs_port
-    del_ovs_flows
-}
-
-case "$action" in
-    setup)
-	lockwrap Setup
-	;;
-    update)
-	lockwrap Update
-	;;
-    teardown)
-	lockwrap Teardown
-	;;
-    *)
-        echo "Bad input: $@"
-        exit 1
-esac
+lockwrap run

--- a/plugins/osdn/subnets.go
+++ b/plugins/osdn/subnets.go
@@ -9,6 +9,8 @@ import (
 
 	"github.com/openshift/openshift-sdn/pkg/netutils"
 	"github.com/openshift/openshift-sdn/plugins/osdn/api"
+	kapi "k8s.io/kubernetes/pkg/api"
+	kubetypes "k8s.io/kubernetes/pkg/kubelet/container"
 )
 
 func (oc *OvsController) SubnetStartMaster(clusterNetworkCIDR string, clusterBitsPerSubnet uint, serviceNetworkCIDR string) error {
@@ -128,6 +130,17 @@ func (oc *OvsController) SubnetStartNode(mtu uint) error {
 	subnets := result.([]api.Subnet)
 	for _, s := range subnets {
 		oc.flowController.AddOFRules(s.NodeIP, s.SubnetCIDR, oc.localIP)
+	}
+
+	pods, err := oc.Registry.GetRunningPods(oc.hostName, kapi.NamespaceAll)
+	if err != nil {
+		return err
+	}
+	for _, p := range pods {
+		err = oc.pluginHooks.UpdatePod(p.Namespace, p.Name, kubetypes.DockerID(p.ContainerID))
+		if err != nil {
+			log.Warningf("Could not update pod %q (%s): %s", p.Name, p.ContainerID, err)
+		}
 	}
 
 	return nil


### PR DESCRIPTION
This (a) improves the plugin script's "UpdatePod" behavior, and (b) calls UpdatePod on every currently-running pod at startup. Which means:

- If br0 was destroyed and recreated, pods will now correctly get reattached (https://bugzilla.redhat.com/show_bug.cgi?id=1299756)
- If ClusterNetworkCIDR changed, pods will get the updated local route (https://github.com/openshift/openshift-sdn/issues/239)

@openshift/networking PTAL