### PR TITLE
Re-fix reconnect-pods-on-restart code

### DIFF
--- a/plugins/osdn/common.go
+++ b/plugins/osdn/common.go
@@ -226,6 +226,10 @@ func (oc *OvsController) StartNode(mtu uint) error {
 	return nil
 }
 
+func (oc *OvsController) GetLocalPods(namespace string) ([]api.Pod, error) {
+	return oc.Registry.GetRunningPods(oc.hostName, namespace)
+}
+
 func (oc *OvsController) markPodNetworkReady() {
 	close(oc.podNetworkReady)
 }

--- a/plugins/osdn/ovs/plugin.go
+++ b/plugins/osdn/ovs/plugin.go
@@ -9,6 +9,7 @@ import (
 	"github.com/openshift/openshift-sdn/plugins/osdn"
 	"github.com/openshift/openshift-sdn/plugins/osdn/api"
 
+	kapi "k8s.io/kubernetes/pkg/api"
 	kubeletTypes "k8s.io/kubernetes/pkg/kubelet/container"
 	knetwork "k8s.io/kubernetes/pkg/kubelet/network"
 	utilexec "k8s.io/kubernetes/pkg/util/exec"
@@ -58,13 +59,27 @@ func (plugin *ovsPlugin) PluginStartMaster(clusterNetworkCIDR string, clusterBit
 }
 
 func (plugin *ovsPlugin) PluginStartNode(mtu uint) error {
-	if err := plugin.SubnetStartNode(mtu); err != nil {
+	networkChanged, err := plugin.SubnetStartNode(mtu)
+	if err != nil {
 		return err
 	}
 
 	if plugin.multitenant {
 		if err := plugin.VnidStartNode(); err != nil {
 			return err
+		}
+	}
+
+	if networkChanged {
+		pods, err := plugin.GetLocalPods(kapi.NamespaceAll)
+		if err != nil {
+			return err
+		}
+		for _, p := range pods {
+			err = plugin.UpdatePod(p.Namespace, p.Name, kubeletTypes.DockerID(p.ContainerID))
+			if err != nil {
+				glog.Warningf("Could not update pod %q (%s): %s", p.Name, p.ContainerID, err)
+			}
 		}
 	}
 

--- a/plugins/osdn/vnids.go
+++ b/plugins/osdn/vnids.go
@@ -218,7 +218,7 @@ func (oc *OvsController) VnidStartNode() error {
 
 func (oc *OvsController) updatePodNetwork(namespace string, netID, oldNetID uint) error {
 	// Update OF rules for the existing/old pods in the namespace
-	pods, err := oc.Registry.GetRunningPods(oc.hostName, namespace)
+	pods, err := oc.GetLocalPods(namespace)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
When using multi-tenant, we need to run VnidStartNode() before updating the pods, to ensure that VNIDMap is initialized. But VnidStartNode() assumes that SubnetStartNode() has already run. So,
move the pod-updating code out of SubnetStartNode() into PluginStartNode().