### PR TITLE
plugin refactoring/cleanup

### DIFF
--- a/plugins/osdn/api/types.go
+++ b/plugins/osdn/api/types.go
@@ -1,6 +1,9 @@
 package api
 
 import (
+	osapi "github.com/openshift/origin/pkg/sdn/api"
+
+	kapi "k8s.io/kubernetes/pkg/api"
 	knetwork "k8s.io/kubernetes/pkg/kubelet/network"
 	pconfig "k8s.io/kubernetes/pkg/proxy/config"
 )
@@ -13,73 +16,29 @@ const (
 	Modified EventType = "MODIFIED"
 )
 
-type Subnet struct {
-	NodeIP     string
-	SubnetCIDR string
-}
-
-type SubnetEvent struct {
-	Type     EventType
-	NodeName string
-	Subnet   Subnet
-}
-
-type Node struct {
-	Name string
-	IP   string
+type HostSubnetEvent struct {
+	Type       EventType
+	HostSubnet *osapi.HostSubnet
 }
 
 type NodeEvent struct {
 	Type EventType
-	Node Node
-}
-
-type NetNamespace struct {
-	Name  string
-	NetID uint
+	Node *kapi.Node
 }
 
 type NetNamespaceEvent struct {
-	Type  EventType
-	Name  string
-	NetID uint
+	Type         EventType
+	NetNamespace *osapi.NetNamespace
 }
 
 type NamespaceEvent struct {
-	Type EventType
-	Name string
-}
-
-type ServiceProtocol string
-
-const (
-	TCP ServiceProtocol = "TCP"
-	UDP ServiceProtocol = "UDP"
-)
-
-type ServicePort struct {
-	Protocol ServiceProtocol
-	Port     uint
-}
-
-type Service struct {
-	Name      string
-	Namespace string
-	UID       string
-	IP        string
-	Ports     []ServicePort
+	Type      EventType
+	Namespace *kapi.Namespace
 }
 
 type ServiceEvent struct {
 	Type    EventType
-	Service Service
-}
-
-type Pod struct {
-	Name        string
-	Namespace   string
-	ContainerID string
-	Annotations map[string]string
+	Service *kapi.Service
 }
 
 type OsdnPlugin interface {

--- a/plugins/osdn/api/types.go
+++ b/plugins/osdn/api/types.go
@@ -1,45 +1,9 @@
 package api
 
 import (
-	osapi "github.com/openshift/origin/pkg/sdn/api"
-
-	kapi "k8s.io/kubernetes/pkg/api"
 	knetwork "k8s.io/kubernetes/pkg/kubelet/network"
 	pconfig "k8s.io/kubernetes/pkg/proxy/config"
 )
-
-type EventType string
-
-const (
-	Added    EventType = "ADDED"
-	Deleted  EventType = "DELETED"
-	Modified EventType = "MODIFIED"
-)
-
-type HostSubnetEvent struct {
-	Type       EventType
-	HostSubnet *osapi.HostSubnet
-}
-
-type NodeEvent struct {
-	Type EventType
-	Node *kapi.Node
-}
-
-type NetNamespaceEvent struct {
-	Type         EventType
-	NetNamespace *osapi.NetNamespace
-}
-
-type NamespaceEvent struct {
-	Type      EventType
-	Namespace *kapi.Namespace
-}
-
-type ServiceEvent struct {
-	Type    EventType
-	Service *kapi.Service
-}
 
 type OsdnPlugin interface {
 	knetwork.NetworkPlugin

--- a/plugins/osdn/common.go
+++ b/plugins/osdn/common.go
@@ -26,11 +26,11 @@ type PluginHooks interface {
 
 	SetupSDN(localSubnetCIDR, clusterNetworkCIDR, serviceNetworkCIDR string, mtu uint) (bool, error)
 
-	AddOFRules(nodeIP, nodeSubnetCIDR, localIP string) error
-	DelOFRules(nodeIP, localIP string) error
+	AddHostSubnetRules(subnet *osapi.HostSubnet)
+	DeleteHostSubnetRules(subnet *osapi.HostSubnet)
 
-	AddServiceOFRules(netID uint, IP string, protocol kapi.Protocol, port int) error
-	DelServiceOFRules(netID uint, IP string, protocol kapi.Protocol, port int) error
+	AddServiceRules(service *kapi.Service, netID uint)
+	DeleteServiceRules(service *kapi.Service, netID uint)
 
 	UpdatePod(namespace string, name string, id kubetypes.DockerID) error
 }

--- a/plugins/osdn/ovs/controller.go
+++ b/plugins/osdn/ovs/controller.go
@@ -13,8 +13,8 @@ import (
 	"github.com/openshift/openshift-sdn/pkg/ipcmd"
 	"github.com/openshift/openshift-sdn/pkg/netutils"
 	"github.com/openshift/openshift-sdn/pkg/ovs"
-	"github.com/openshift/openshift-sdn/plugins/osdn/api"
 
+	kapi "k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/util/sysctl"
 )
 
@@ -372,7 +372,7 @@ func generateCookie(ip string) string {
 	return hex.EncodeToString(net.ParseIP(ip).To4())
 }
 
-func (plugin *ovsPlugin) AddServiceOFRules(netID uint, IP string, protocol api.ServiceProtocol, port uint) error {
+func (plugin *ovsPlugin) AddServiceOFRules(netID uint, IP string, protocol kapi.Protocol, port int) error {
 	if !plugin.multitenant {
 		return nil
 	}
@@ -388,7 +388,7 @@ func (plugin *ovsPlugin) AddServiceOFRules(netID uint, IP string, protocol api.S
 	return err
 }
 
-func (plugin *ovsPlugin) DelServiceOFRules(netID uint, IP string, protocol api.ServiceProtocol, port uint) error {
+func (plugin *ovsPlugin) DelServiceOFRules(netID uint, IP string, protocol kapi.Protocol, port int) error {
 	if !plugin.multitenant {
 		return nil
 	}
@@ -404,11 +404,11 @@ func (plugin *ovsPlugin) DelServiceOFRules(netID uint, IP string, protocol api.S
 	return err
 }
 
-func generateBaseServiceRule(IP string, protocol api.ServiceProtocol, port uint) string {
+func generateBaseServiceRule(IP string, protocol kapi.Protocol, port int) string {
 	return fmt.Sprintf("table=4, %s, nw_dst=%s, tp_dst=%d", strings.ToLower(string(protocol)), IP, port)
 }
 
-func generateAddServiceRule(netID uint, IP string, protocol api.ServiceProtocol, port uint) string {
+func generateAddServiceRule(netID uint, IP string, protocol kapi.Protocol, port int) string {
 	baseRule := generateBaseServiceRule(IP, protocol, port)
 	if netID == 0 {
 		return fmt.Sprintf("%s, priority=100, actions=output:2", baseRule)
@@ -417,6 +417,6 @@ func generateAddServiceRule(netID uint, IP string, protocol api.ServiceProtocol,
 	}
 }
 
-func generateDelServiceRule(IP string, protocol api.ServiceProtocol, port uint) string {
+func generateDelServiceRule(IP string, protocol kapi.Protocol, port int) string {
 	return generateBaseServiceRule(IP, protocol, port)
 }

--- a/plugins/osdn/ovs/plugin.go
+++ b/plugins/osdn/ovs/plugin.go
@@ -18,7 +18,7 @@ import (
 )
 
 type ovsPlugin struct {
-	osdn.OvsController
+	osdn.OsdnController
 
 	multitenant bool
 }

--- a/plugins/osdn/ovs/plugin.go
+++ b/plugins/osdn/ovs/plugin.go
@@ -34,7 +34,7 @@ func MultiTenantPluginName() string {
 func CreatePlugin(registry *osdn.Registry, multitenant bool, hostname string, selfIP string) (api.OsdnPlugin, api.FilteringEndpointsConfigHandler, error) {
 	plugin := &ovsPlugin{multitenant: multitenant}
 
-	err := plugin.BaseInit(registry, NewFlowController(multitenant), plugin, hostname, selfIP)
+	err := plugin.BaseInit(registry, plugin, hostname, selfIP)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/plugins/osdn/ovs/plugin.go
+++ b/plugins/osdn/ovs/plugin.go
@@ -78,9 +78,10 @@ func (plugin *ovsPlugin) PluginStartNode(mtu uint) error {
 			return err
 		}
 		for _, p := range pods {
-			err = plugin.UpdatePod(p.Namespace, p.Name, kubeletTypes.DockerID(p.ContainerID))
+			containerID := osdn.GetPodContainerID(&p)
+			err = plugin.UpdatePod(p.Namespace, p.Name, kubeletTypes.DockerID(containerID))
 			if err != nil {
-				glog.Warningf("Could not update pod %q (%s): %s", p.Name, p.ContainerID, err)
+				glog.Warningf("Could not update pod %q (%s): %s", p.Name, containerID, err)
 			}
 		}
 	}
@@ -143,7 +144,7 @@ func parseAndValidateBandwidth(value string) (int64, error) {
 	return rsrc.Value(), nil
 }
 
-func extractBandwidthResources(pod *api.Pod) (ingress, egress int64, err error) {
+func extractBandwidthResources(pod *kapi.Pod) (ingress, egress int64, err error) {
 	str, found := pod.Annotations["kubernetes.io/ingress-bandwidth"]
 	if found {
 		ingress, err = parseAndValidateBandwidth(str)

--- a/plugins/osdn/subnets.go
+++ b/plugins/osdn/subnets.go
@@ -111,7 +111,7 @@ func (oc *OsdnController) SubnetStartNode(mtu uint) (bool, error) {
 		log.Errorf("Failed to obtain ClusterNetwork: %v", err)
 		return false, err
 	}
-	networkChanged, err := oc.flowController.Setup(oc.localSubnet.SubnetCIDR, clusterNetwork.String(), servicesNetwork.String(), mtu)
+	networkChanged, err := oc.pluginHooks.SetupSDN(oc.localSubnet.SubnetCIDR, clusterNetwork.String(), servicesNetwork.String(), mtu)
 	if err != nil {
 		return false, err
 	}
@@ -125,7 +125,7 @@ func (oc *OsdnController) SubnetStartNode(mtu uint) (bool, error) {
 	}
 	subnets := result.([]api.Subnet)
 	for _, s := range subnets {
-		oc.flowController.AddOFRules(s.NodeIP, s.SubnetCIDR, oc.localIP)
+		oc.pluginHooks.AddOFRules(s.NodeIP, s.SubnetCIDR, oc.localIP)
 	}
 
 	return networkChanged, nil
@@ -227,10 +227,10 @@ func watchSubnets(oc *OsdnController, ready chan<- bool, start <-chan string) {
 					continue
 				}
 				// add openflow rules
-				oc.flowController.AddOFRules(ev.Subnet.NodeIP, ev.Subnet.SubnetCIDR, oc.localIP)
+				oc.pluginHooks.AddOFRules(ev.Subnet.NodeIP, ev.Subnet.SubnetCIDR, oc.localIP)
 			case api.Deleted:
 				// delete openflow rules meant for the node
-				oc.flowController.DelOFRules(ev.Subnet.NodeIP, oc.localIP)
+				oc.pluginHooks.DelOFRules(ev.Subnet.NodeIP, oc.localIP)
 			}
 		case <-oc.sig:
 			stop <- true

--- a/plugins/osdn/subnets.go
+++ b/plugins/osdn/subnets.go
@@ -11,7 +11,7 @@ import (
 	"github.com/openshift/openshift-sdn/plugins/osdn/api"
 )
 
-func (oc *OvsController) SubnetStartMaster(clusterNetwork *net.IPNet, hostSubnetLength uint) error {
+func (oc *OsdnController) SubnetStartMaster(clusterNetwork *net.IPNet, hostSubnetLength uint) error {
 	subrange := make([]string, 0)
 	subnets, _, err := oc.Registry.GetSubnets()
 	if err != nil {
@@ -61,7 +61,7 @@ func (oc *OvsController) SubnetStartMaster(clusterNetwork *net.IPNet, hostSubnet
 	return nil
 }
 
-func (oc *OvsController) addNode(nodeName string, nodeIP string) error {
+func (oc *OsdnController) addNode(nodeName string, nodeIP string) error {
 	sn, err := oc.subnetAllocator.GetNetwork()
 	if err != nil {
 		log.Errorf("Error creating network for node %s.", nodeName)
@@ -84,7 +84,7 @@ func (oc *OvsController) addNode(nodeName string, nodeIP string) error {
 	return nil
 }
 
-func (oc *OvsController) deleteNode(nodeName string) error {
+func (oc *OsdnController) deleteNode(nodeName string) error {
 	sub, err := oc.Registry.GetSubnet(nodeName)
 	if err != nil {
 		log.Errorf("Error fetching subnet for node %s for delete operation.", nodeName)
@@ -99,7 +99,7 @@ func (oc *OvsController) deleteNode(nodeName string) error {
 	return oc.Registry.DeleteSubnet(nodeName)
 }
 
-func (oc *OvsController) SubnetStartNode(mtu uint) (bool, error) {
+func (oc *OsdnController) SubnetStartNode(mtu uint) (bool, error) {
 	err := oc.initSelfSubnet()
 	if err != nil {
 		return false, err
@@ -131,7 +131,7 @@ func (oc *OvsController) SubnetStartNode(mtu uint) (bool, error) {
 	return networkChanged, nil
 }
 
-func (oc *OvsController) initSelfSubnet() error {
+func (oc *OsdnController) initSelfSubnet() error {
 	// timeout: 30 secs
 	retries := 60
 	retryInterval := 500 * time.Millisecond
@@ -161,7 +161,7 @@ func (oc *OvsController) initSelfSubnet() error {
 }
 
 // Only run on the master
-func watchNodes(oc *OvsController, ready chan<- bool, start <-chan string) {
+func watchNodes(oc *OsdnController, ready chan<- bool, start <-chan string) {
 	stop := make(chan bool)
 	nodeEvent := make(chan *api.NodeEvent)
 	go oc.Registry.WatchNodes(nodeEvent, ready, start, stop)
@@ -213,7 +213,7 @@ func watchNodes(oc *OvsController, ready chan<- bool, start <-chan string) {
 }
 
 // Only run on the nodes
-func watchSubnets(oc *OvsController, ready chan<- bool, start <-chan string) {
+func watchSubnets(oc *OsdnController, ready chan<- bool, start <-chan string) {
 	stop := make(chan bool)
 	clusterEvent := make(chan *api.SubnetEvent)
 	go oc.Registry.WatchSubnets(clusterEvent, ready, start, stop)
@@ -239,7 +239,7 @@ func watchSubnets(oc *OvsController, ready chan<- bool, start <-chan string) {
 	}
 }
 
-func (oc *OvsController) validateNode(nodeIP string) error {
+func (oc *OsdnController) validateNode(nodeIP string) error {
 	clusterNet, err := oc.Registry.GetClusterNetwork()
 	if err != nil {
 		return fmt.Errorf("Failed to get Cluster Network address: %v", err)

--- a/plugins/osdn/vnids.go
+++ b/plugins/osdn/vnids.go
@@ -201,7 +201,7 @@ func (oc *OsdnController) VnidStartNode() error {
 		}
 		oc.services[svc.UID] = svc
 		for _, port := range svc.Ports {
-			oc.flowController.AddServiceOFRules(netid, svc.IP, port.Protocol, port.Port)
+			oc.pluginHooks.AddServiceOFRules(netid, svc.IP, port.Protocol, port.Port)
 		}
 	}
 
@@ -236,8 +236,8 @@ func (oc *OsdnController) updatePodNetwork(namespace string, netID, oldNetID uin
 	}
 	for _, svc := range services {
 		for _, port := range svc.Ports {
-			oc.flowController.DelServiceOFRules(oldNetID, svc.IP, port.Protocol, port.Port)
-			oc.flowController.AddServiceOFRules(netID, svc.IP, port.Protocol, port.Port)
+			oc.pluginHooks.DelServiceOFRules(oldNetID, svc.IP, port.Protocol, port.Port)
+			oc.pluginHooks.AddServiceOFRules(netID, svc.IP, port.Protocol, port.Port)
 		}
 	}
 	return nil
@@ -295,12 +295,12 @@ func watchServices(oc *OsdnController, ready chan<- bool, start <-chan string) {
 			case api.Added:
 				oc.services[ev.Service.UID] = ev.Service
 				for _, port := range ev.Service.Ports {
-					oc.flowController.AddServiceOFRules(netid, ev.Service.IP, port.Protocol, port.Port)
+					oc.pluginHooks.AddServiceOFRules(netid, ev.Service.IP, port.Protocol, port.Port)
 				}
 			case api.Deleted:
 				delete(oc.services, ev.Service.UID)
 				for _, port := range ev.Service.Ports {
-					oc.flowController.DelServiceOFRules(netid, ev.Service.IP, port.Protocol, port.Port)
+					oc.pluginHooks.DelServiceOFRules(netid, ev.Service.IP, port.Protocol, port.Port)
 				}
 			case api.Modified:
 				oldsvc, exists := oc.services[ev.Service.UID]
@@ -318,12 +318,12 @@ func watchServices(oc *OsdnController, ready chan<- bool, start <-chan string) {
 				}
 				if exists {
 					for _, port := range oldsvc.Ports {
-						oc.flowController.DelServiceOFRules(netid, oldsvc.IP, port.Protocol, port.Port)
+						oc.pluginHooks.DelServiceOFRules(netid, oldsvc.IP, port.Protocol, port.Port)
 					}
 				}
 				oc.services[ev.Service.UID] = ev.Service
 				for _, port := range ev.Service.Ports {
-					oc.flowController.AddServiceOFRules(netid, ev.Service.IP, port.Protocol, port.Port)
+					oc.pluginHooks.AddServiceOFRules(netid, ev.Service.IP, port.Protocol, port.Port)
 				}
 			}
 		case <-oc.sig:

--- a/plugins/osdn/vnids.go
+++ b/plugins/osdn/vnids.go
@@ -17,7 +17,7 @@ const (
 	AdminVNID = uint(0)
 )
 
-func (oc *OvsController) VnidStartMaster() error {
+func (oc *OsdnController) VnidStartMaster() error {
 	nets, _, err := oc.Registry.GetNetNamespaces()
 	if err != nil {
 		return err
@@ -73,7 +73,7 @@ func (oc *OvsController) VnidStartMaster() error {
 	return nil
 }
 
-func (oc *OvsController) isAdminNamespace(nsName string) bool {
+func (oc *OsdnController) isAdminNamespace(nsName string) bool {
 	for _, name := range oc.adminNamespaces {
 		if name == nsName {
 			return true
@@ -82,7 +82,7 @@ func (oc *OvsController) isAdminNamespace(nsName string) bool {
 	return false
 }
 
-func (oc *OvsController) assignVNID(namespaceName string) error {
+func (oc *OsdnController) assignVNID(namespaceName string) error {
 	_, err := oc.Registry.GetNetNamespace(namespaceName)
 	if err == nil {
 		return nil
@@ -109,7 +109,7 @@ func (oc *OvsController) assignVNID(namespaceName string) error {
 	return nil
 }
 
-func (oc *OvsController) revokeVNID(namespaceName string) error {
+func (oc *OsdnController) revokeVNID(namespaceName string) error {
 	err := oc.Registry.DeleteNetNamespace(namespaceName)
 	if err != nil {
 		return err
@@ -143,7 +143,7 @@ func (oc *OvsController) revokeVNID(namespaceName string) error {
 	return nil
 }
 
-func watchNamespaces(oc *OvsController, ready chan<- bool, start <-chan string) {
+func watchNamespaces(oc *OsdnController, ready chan<- bool, start <-chan string) {
 	nsevent := make(chan *api.NamespaceEvent)
 	stop := make(chan bool)
 	go oc.Registry.WatchNamespaces(nsevent, ready, start, stop)
@@ -172,7 +172,7 @@ func watchNamespaces(oc *OvsController, ready chan<- bool, start <-chan string) 
 	}
 }
 
-func (oc *OvsController) VnidStartNode() error {
+func (oc *OsdnController) VnidStartNode() error {
 	getNetNamespaces := func(registry *Registry) (interface{}, string, error) {
 		return registry.GetNetNamespaces()
 	}
@@ -216,7 +216,7 @@ func (oc *OvsController) VnidStartNode() error {
 	return nil
 }
 
-func (oc *OvsController) updatePodNetwork(namespace string, netID, oldNetID uint) error {
+func (oc *OsdnController) updatePodNetwork(namespace string, netID, oldNetID uint) error {
 	// Update OF rules for the existing/old pods in the namespace
 	pods, err := oc.GetLocalPods(namespace)
 	if err != nil {
@@ -243,7 +243,7 @@ func (oc *OvsController) updatePodNetwork(namespace string, netID, oldNetID uint
 	return nil
 }
 
-func watchNetNamespaces(oc *OvsController, ready chan<- bool, start <-chan string) {
+func watchNetNamespaces(oc *OsdnController, ready chan<- bool, start <-chan string) {
 	stop := make(chan bool)
 	netNsEvent := make(chan *api.NetNamespaceEvent)
 	go oc.Registry.WatchNetNamespaces(netNsEvent, ready, start, stop)
@@ -280,7 +280,7 @@ func watchNetNamespaces(oc *OvsController, ready chan<- bool, start <-chan strin
 	}
 }
 
-func watchServices(oc *OvsController, ready chan<- bool, start <-chan string) {
+func watchServices(oc *OsdnController, ready chan<- bool, start <-chan string) {
 	stop := make(chan bool)
 	svcevent := make(chan *api.ServiceEvent)
 	go oc.Registry.WatchServices(svcevent, ready, start, stop)
@@ -334,7 +334,7 @@ func watchServices(oc *OvsController, ready chan<- bool, start <-chan string) {
 	}
 }
 
-func watchPods(oc *OvsController, ready chan<- bool, start <-chan string) {
+func watchPods(oc *OsdnController, ready chan<- bool, start <-chan string) {
 	stop := make(chan bool)
 	go oc.Registry.WatchPods(ready, start, stop)
 


### PR DESCRIPTION
The individual commit messages mostly explain the changes here...

The change to get rid of the wrapper types was inspired by the egress router work: I wanted to be able to check the pod's SecurityContext from plugin.go, which would have required copying that info from kapi.Pod to osdnapi.Pod, much as dcbw had just done for annotations... but that seemed silly when we could just use the kapi.Pod directly instead.

@openshift/networking PTAL