### PR TITLE
Add annotation for adding macvlan interface to pod (for egress-router)

### DIFF
--- a/plugins/osdn/ovs/bin/openshift-sdn-ovs
+++ b/plugins/osdn/ovs/bin/openshift-sdn-ovs
@@ -8,6 +8,7 @@ net_container=$2
 tenant_id=$3
 ingress_bw=$4
 egress_bw=$5
+macvlan=$6
 
 lockwrap() {
     (
@@ -115,6 +116,16 @@ ensure_subnet_route() {
     add_subnet_route
 }
 
+add_macvlan() {
+    default_dev=$(ip route show | sed -ne 's/^default .* dev \([^ ]*\) .*/\1/p')
+    if [ -z "$default_dev" ]; then
+	echo "Could not find default network interface"
+	exit 1
+    fi
+    ip link add link $default_dev name macvlan0 type macvlan mode private
+    ip link set macvlan0 netns $pid
+}
+
 run() {
     get_ipaddr_pid_veth
     source /run/openshift-sdn/config.env
@@ -124,6 +135,9 @@ run() {
 	    add_ovs_port
 	    add_ovs_flows
 	    add_subnet_route
+	    if [ "$macvlan" = true ]; then
+		add_macvlan
+	    fi
 	    ;;
 
 	update)


### PR DESCRIPTION
This builds on the refactoring in #270; only the final commit ("Implement "openshift.io/macvlan" annotation on pods") is new

With this addition, you can run https://github.com/danwinship/egress-router, and this should be considered in that context.

We had talked before about whether implementing egress IPs as a pod made sense, and I eventually decided that it does:
- It provides an obvious way to enable/disable the service.
- It keeps the logic outside of openshift-sdn/origin, so we can deprecate/replace it later if we need to.
- You can point a service at the pod and then other pods refer to it by that and don't need to know the details of where it's running.
- You can use a nodeSelector on the pod to force it to only be deployed to nodes that are capable of using the egress IP.
- If the node running the egress router pod goes down, it can automatically get deployed to another node. (There had been discussion of whether it would make more sense to tie that into the existing "high availability" stuff, but that is about keeping publicly-visible IPs working, and doesn't really match what we're doing here.)
- Isolation is already taken care of
- If the functionality is implemented in certain ways, then everything gets cleaned up automatically when the pod's network namespace is deleted, even if the pod was killed uncleanly.

The one catch is that you end up wanting the pod to have its own network namespace and get assigned a ClusterNetwork IP address by openshift-sdn, but you also need to run a small bit of setup code in the host's network namespace. So that's what this PR does.

Some open questions:
- Is the annotation name appropriate? (We already have some other "openshift.io/" annotations, such as "openshift.io/scc").
- Is the "privileged" requirement appropriate? The pod really only needs CAP_NET_ADMIN (I think; not tested), but none of the preexisting SecurityContextConstraints will let you add capabilities to your container SecurityContext, so if we did it that way, you'd need to create a new SCC before you could create the router. (Or we could add it to the default set I guess.)
- Is this feature the right one to add? Another possibility would be, rather than adding code to openshift-sdn-ovs, to allow the pod to provide its own additional startup script to run (sort of like the existing PostStart hook, except running outside the container). That might also be useful for other features, but also seems pretty dangerous... (I'm not sure if the macvlan feature is likely to be useful for anything other than the egress router...)

@openshift/networking PTAL