### PR TITLE
Fix network pod teardown

### DIFF
--- a/plugins/osdn/ovs/bin/openshift-sdn-ovs
+++ b/plugins/osdn/ovs/bin/openshift-sdn-ovs
@@ -134,8 +134,9 @@ run() {
 	    ;;
 
 	teardown)
-	    del_ovs_port
 	    del_ovs_flows
+	    # Delete ovs port in the end, del_ovs_flows needs the port to delete qos record
+	    del_ovs_port
 	    ;;
 
 	*)


### PR DESCRIPTION
del_ovs_flows() uses ovs port to fetch qos record,
so delete ovs port in the end.

Bug fix for https://bugzilla.redhat.com/show_bug.cgi?id=1322077