### PR TITLE
Fix watch services for multitenant plugin

### DIFF
--- a/plugins/osdn/common.go
+++ b/plugins/osdn/common.go
@@ -30,7 +30,7 @@ type PluginHooks interface {
 	DeleteHostSubnetRules(subnet *osapi.HostSubnet)
 
 	AddServiceRules(service *kapi.Service, netID uint)
-	DeleteServiceRules(service *kapi.Service, netID uint)
+	DeleteServiceRules(service *kapi.Service)
 
 	UpdatePod(namespace string, name string, id kubetypes.DockerID) error
 }

--- a/plugins/osdn/ovs/controller.go
+++ b/plugins/osdn/ovs/controller.go
@@ -380,7 +380,7 @@ func (plugin *ovsPlugin) AddServiceRules(service *kapi.Service, netID uint) {
 	}
 }
 
-func (plugin *ovsPlugin) DeleteServiceRules(service *kapi.Service, netID uint) {
+func (plugin *ovsPlugin) DeleteServiceRules(service *kapi.Service) {
 	if !plugin.multitenant {
 		return
 	}

--- a/plugins/osdn/vnids.go
+++ b/plugins/osdn/vnids.go
@@ -216,7 +216,7 @@ func (oc *OsdnController) VnidStartNode() error {
 	return nil
 }
 
-func (oc *OsdnController) updatePodNetwork(namespace string, netID, oldNetID uint) error {
+func (oc *OsdnController) updatePodNetwork(namespace string, netID uint) error {
 	// Update OF rules for the existing/old pods in the namespace
 	pods, err := oc.GetLocalPods(namespace)
 	if err != nil {
@@ -235,7 +235,7 @@ func (oc *OsdnController) updatePodNetwork(namespace string, netID, oldNetID uin
 		return err
 	}
 	for _, svc := range services {
-		oc.pluginHooks.DeleteServiceRules(&svc, oldNetID)
+		oc.pluginHooks.DeleteServiceRules(&svc)
 		oc.pluginHooks.AddServiceRules(&svc, netID)
 	}
 	return nil
@@ -259,12 +259,12 @@ func watchNetNamespaces(oc *OsdnController, ready chan<- bool, start <-chan stri
 					continue
 				}
 				oc.VNIDMap[ev.NetNamespace.Name] = ev.NetNamespace.NetID
-				err := oc.updatePodNetwork(ev.NetNamespace.NetName, ev.NetNamespace.NetID, oldNetID)
+				err := oc.updatePodNetwork(ev.NetNamespace.NetName, ev.NetNamespace.NetID)
 				if err != nil {
 					log.Errorf("Failed to update pod network for namespace '%s', error: %s", ev.NetNamespace.NetName, err)
 				}
 			case Deleted:
-				err := oc.updatePodNetwork(ev.NetNamespace.NetName, AdminVNID, oldNetID)
+				err := oc.updatePodNetwork(ev.NetNamespace.NetName, AdminVNID)
 				if err != nil {
 					log.Errorf("Failed to update pod network for namespace '%s', error: %s", ev.NetNamespace.NetName, err)
 				}
@@ -285,9 +285,14 @@ func watchServices(oc *OsdnController, ready chan<- bool, start <-chan string) {
 	for {
 		select {
 		case ev := <-svcevent:
-			netid, found := oc.VNIDMap[ev.Service.Namespace]
-			if !found {
-				log.Errorf("Error fetching Net ID for namespace: %s, skipped serviceEvent: %v", ev.Service.Namespace, ev)
+			var netid uint
+			if ev.Type != Deleted {
+				var found bool
+				netid, found = oc.VNIDMap[ev.Service.Namespace]
+				if !found {
+					log.Errorf("Error fetching Net ID for namespace: %s, skipped serviceEvent: %v", ev.Service.Namespace, ev)
+					continue
+				}
 			}
 			switch ev.Type {
 			case Added:
@@ -295,7 +300,7 @@ func watchServices(oc *OsdnController, ready chan<- bool, start <-chan string) {
 				oc.pluginHooks.AddServiceRules(ev.Service, netid)
 			case Deleted:
 				delete(oc.services, string(ev.Service.UID))
-				oc.pluginHooks.DeleteServiceRules(ev.Service, netid)
+				oc.pluginHooks.DeleteServiceRules(ev.Service)
 			case Modified:
 				oldsvc, exists := oc.services[string(ev.Service.UID)]
 				if exists && len(oldsvc.Spec.Ports) == len(ev.Service.Spec.Ports) {
@@ -311,7 +316,7 @@ func watchServices(oc *OsdnController, ready chan<- bool, start <-chan string) {
 					}
 				}
 				if exists {
-					oc.pluginHooks.DeleteServiceRules(oldsvc, netid)
+					oc.pluginHooks.DeleteServiceRules(oldsvc)
 				}
 				oc.services[string(ev.Service.UID)] = ev.Service
 				oc.pluginHooks.AddServiceRules(ev.Service, netid)


### PR DESCRIPTION
- Don't perform AddServiceRules with global/zero vnid when the vnid is not found in the VNIDMap
- We don't need to pass vnid for DeleteServiceRules