### PR TITLE
Added 'docker ps -a' to the node debug items

### DIFF
--- a/hack/debug.sh
+++ b/hack/debug.sh
@@ -268,6 +268,7 @@ do_node () {
 
     # Log some node-only information
     echo_and_eval  brctl show                              &> $lognode/bridges
+    echo_and_eval  docker ps -a                            &> $lognode/docker-ps
     echo_and_eval  ovs-ofctl -O OpenFlow13 dump-flows br0  &> $lognode/flows
     echo_and_eval  ovs-ofctl -O OpenFlow13 show br0        &> $lognode/ovs-show
     echo_and_eval  systemctl cat docker.service            &> $lognode/docker-unit-file


### PR DESCRIPTION
It would have been handy to see the docker state vs. the openshift state for containers for a bug I was working on.  This addresses that deficiency.