### PR TITLE
debug.sh fixes for vxlan anti-spoofing

### DIFF
--- a/hack/debug.sh
+++ b/hack/debug.sh
@@ -456,14 +456,15 @@ do_master_and_nodes ()
 
 ######## Main program starts here
 
-systemd_dir=/usr/lib/systemd/system/
-for name in openshift origin atomic-openshift; do
-    if [ -f $systemd_dir/$name-master.service ]; then
-	aos_master_service=$name-master.service
-    fi
-    if [ -f $systemd_dir/$name-node.service ]; then
-	aos_node_service=$name-node.service
-    fi
+for systemd_dir in /etc/systemd/system /usr/lib/systemd/system; do
+    for name in openshift origin atomic-openshift; do
+	if [ -f $systemd_dir/$name-master.service ]; then
+	    aos_master_service=$name-master.service
+	fi
+	if [ -f $systemd_dir/$name-node.service ]; then
+	    aos_node_service=$name-node.service
+	fi
+    done
 done
 
 case "$1" in

--- a/hack/debug.sh
+++ b/hack/debug.sh
@@ -113,7 +113,7 @@ do_master () {
     # Outputs a list of pods in the form "minion-1 mypod namespace 10.1.0.2 e4f1d61b"
     oc get pods --all-namespaces --template '{{range .items}}{{if .status.containerStatuses}}{{if (index .status.containerStatuses 0).ready}}{{if not .spec.hostNetwork}}{{.spec.nodeName}} {{.metadata.name}} {{.metadata.namespace}} {{.status.podIP}} {{printf "%.21s" (index .status.containerStatuses 0).containerID}}{{"\n"}}{{end}}{{end}}{{end}}{{end}}' | sed -e 's|docker://||' > $logdir/meta/podinfo
 
-    # Outputs a list of services in the form "myservice:namespace:172.30.0.99:tcp:5454"
+    # Outputs a list of services in the form "myservice namespace 172.30.0.99 tcp 5454"
     oc get services --all-namespaces --template '{{range .items}}{{if ne .spec.clusterIP "None"}}{{.metadata.name}} {{.metadata.namespace}} {{.spec.clusterIP}} {{(index .spec.ports 0).protocol}} {{(index .spec.ports 0).port}}{{"\n"}}{{end}}{{end}}' | sed -e 's/ TCP / tcp /g' -e 's/ UDP / udp /g' > $logdir/meta/serviceinfo
 }
 

--- a/hack/debug.sh
+++ b/hack/debug.sh
@@ -92,16 +92,18 @@ do_master () {
 	    continue
 	fi
 
-	resolv_ip=$(awk '/\s'$node'$/ { print $1; exit; }' /etc/hosts)
-	if [ -z "$resolv_ip" ]; then
-	    resolv_ip=$(host $node 2>/dev/null | sed -ne 's/.*has address //p' | head -1)
+	if ! [[ $node =~ ^[0-9.]*$ ]]; then
+	    resolv_ip=$(awk '/\s'$node'$/ { print $1; exit; }' /etc/hosts)
 	    if [ -z "$resolv_ip" ]; then
-		echo "Node $node: no IP address in either DNS or /etc/hosts"
+		resolv_ip=$(host $node 2>/dev/null | sed -ne 's/.*has address //p' | head -1)
+		if [ -z "$resolv_ip" ]; then
+		    echo "Node $node: no IP address in either DNS or /etc/hosts"
+		fi
 	    fi
-	fi
 
-	if [ "$reg_ip" != "$resolv_ip" ]; then
-	    echo "Node $node: the IP in OpenShift ($reg_ip) does not match DNS/hosts ($resolv_ip)"
+	    if [ "$reg_ip" != "$resolv_ip" ]; then
+		echo "Node $node: the IP in OpenShift ($reg_ip) does not match DNS/hosts ($resolv_ip)"
+	    fi
 	fi
 
 	try_eval ping -c1 -W2 $node


### PR DESCRIPTION
Our OpenFlow rules now try to prevent vxlan spoofing, but the test packet traces in debug.sh didn't get updated for that, so they're now seen as being spoofed and get dropped when they shouldn't

(also another minor fix for dind cluster support)

@openshift/networking 