### PR TITLE
Add a mutex to registry.podsByIP

### DIFF
--- a/plugins/osdn/registry.go
+++ b/plugins/osdn/registry.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net"
 	"strings"
+	"sync"
 
 	log "github.com/golang/glog"
 
@@ -28,6 +29,7 @@ type Registry struct {
 	oClient          *osclient.Client
 	kClient          *kclient.Client
 	podsByIP         map[string]*kapi.Pod
+	podTrackingLock  sync.Mutex
 	serviceNetwork   *net.IPNet
 	clusterNetwork   *net.IPNet
 	hostSubnetLength int
@@ -472,7 +474,7 @@ EndpointLoop:
 					continue EndpointLoop
 				}
 				if clusterNetwork.Contains(IP) {
-					podInfo, ok := registry.podsByIP[addr.IP]
+					podInfo, ok := registry.getTrackedPod(addr.IP)
 					if !ok {
 						log.Warningf("Service '%s' in namespace '%s' has an Endpoint pointing to non-existent pod (%s)", ep.ObjectMeta.Name, ns, addr.IP)
 						continue EndpointLoop
@@ -490,11 +492,21 @@ EndpointLoop:
 	registry.baseEndpointsHandler.OnEndpointsUpdate(filteredEndpoints)
 }
 
+func (registry *Registry) getTrackedPod(ip string) (*kapi.Pod, bool) {
+	registry.podTrackingLock.Lock()
+	defer registry.podTrackingLock.Unlock()
+
+	pod, ok := registry.podsByIP[ip]
+	return pod, ok
+}
+
 func (registry *Registry) trackPod(pod *kapi.Pod) {
 	if pod.Status.PodIP == "" {
 		return
 	}
 
+	registry.podTrackingLock.Lock()
+	defer registry.podTrackingLock.Unlock()
 	podInfo, ok := registry.podsByIP[pod.Status.PodIP]
 
 	if pod.Status.Phase == kapi.PodPending || pod.Status.Phase == kapi.PodRunning {
@@ -512,13 +524,16 @@ func (registry *Registry) trackPod(pod *kapi.Pod) {
 	} else if ok && podInfo.UID == pod.UID {
 		// If the UIDs match, then this pod is moving to a state that indicates it is not running
 		// so we need to remove it from the cache
-		registry.unTrackPod(pod)
+		delete(registry.podsByIP, pod.Status.PodIP)
 	}
 
 	return
 }
 
 func (registry *Registry) unTrackPod(pod *kapi.Pod) {
+	registry.podTrackingLock.Lock()
+	defer registry.podTrackingLock.Unlock()
+
 	// Only delete if the pod ID is the one we are tracking (in case there is a failed or complete
 	// pod lying around that gets deleted while there is a running pod with the same IP)
 	if podInfo, ok := registry.podsByIP[pod.Status.PodIP]; ok && podInfo.UID == pod.UID {


### PR DESCRIPTION
The pod-monitoring and endpoint-filtering threads might both run at the same time so we need a mutex here. Fixes #291.

As for the actual race condition, if a pod which is an endpoint is added, and OnEndpointsUpdate() ends up running before trackPod(), then the pod won't be allowed as an endpoint and will be ignored until the
next time OnEndpointsUpdate() runs, when it will get picked up. So isolation is guaranteed but correct functioning of the service is not...

But can that actually happen? It seems unlikely unless there's really unfair thread scheduling... (The more common case is that trackPod/unTrackPod and OnEndpointsUpdates are running at the same time for unrelated reasons.) Anyway, we don't like this code and want it to go away and be replaced by something else anyway...

@openshift/networking PTAL