### PR TITLE
Update for origin kubernetes rebase

### DIFF
--- a/pkg/cmd/admin/network/project_options.go
+++ b/pkg/cmd/admin/network/project_options.go
@@ -55,7 +55,7 @@ func (p *ProjectOptions) Complete(f *clientcmd.Factory, c *cobra.Command, args [
 	if err != nil {
 		return err
 	}
-	mapper, typer := f.Object()
+	mapper, typer := f.Object(false)
 
 	p.DefaultNamespace = defaultNamespace
 	p.Oclient = oc

--- a/plugins/osdn/ovs/plugin.go
+++ b/plugins/osdn/ovs/plugin.go
@@ -16,6 +16,7 @@ import (
 	"k8s.io/kubernetes/pkg/api/resource"
 	kubeletTypes "k8s.io/kubernetes/pkg/kubelet/container"
 	knetwork "k8s.io/kubernetes/pkg/kubelet/network"
+	utilsets "k8s.io/kubernetes/pkg/util/sets"
 )
 
 type ovsPlugin struct {
@@ -113,6 +114,10 @@ func (plugin *ovsPlugin) Name() string {
 	} else {
 		return SingleTenantPluginName()
 	}
+}
+
+func (plugin *ovsPlugin) Capabilities() utilsets.Int {
+	return utilsets.NewInt(knetwork.NET_PLUGIN_CAPABILITY_SHAPING)
 }
 
 func (plugin *ovsPlugin) getVNID(namespace string) (string, error) {


### PR DESCRIPTION
Also adds the SHAPING capability to the plugin quiet the kubernetes
warning when shaping annotations are present and openshift-sdn handles
them.