### PR TITLE
Refer SDN plugin names and annotations by constants

### DIFF
--- a/plugins/osdn/factory/factory.go
+++ b/plugins/osdn/factory/factory.go
@@ -15,9 +15,9 @@ import (
 // Call by higher layers to create the plugin instance
 func NewPlugin(pluginType string, osClient *osclient.Client, kClient *kclient.Client, hostname string, selfIP string) (api.OsdnPlugin, api.FilteringEndpointsConfigHandler, error) {
 	switch strings.ToLower(pluginType) {
-	case ovs.SingleTenantPluginName():
+	case ovs.SingleTenantPluginName:
 		return ovs.CreatePlugin(osdn.NewRegistry(osClient, kClient), false, hostname, selfIP)
-	case ovs.MultiTenantPluginName():
+	case ovs.MultiTenantPluginName:
 		return ovs.CreatePlugin(osdn.NewRegistry(osClient, kClient), true, hostname, selfIP)
 	}
 

--- a/plugins/osdn/ovs/controller.go
+++ b/plugins/osdn/ovs/controller.go
@@ -325,14 +325,6 @@ func (plugin *ovsPlugin) SetupSDN(localSubnetCIDR, clusterNetworkCIDR, servicesN
 	return true, nil
 }
 
-func (plugin *ovsPlugin) GetName() string {
-	if plugin.multitenant {
-		return MultiTenantPluginName()
-	} else {
-		return SingleTenantPluginName()
-	}
-}
-
 func (plugin *ovsPlugin) AddHostSubnetRules(subnet *osapi.HostSubnet) {
 	glog.Infof("AddHostSubnetRules for %s", osdn.HostSubnetToString(subnet))
 	otx := ovs.NewTransaction(BR)


### PR DESCRIPTION
Remove unused GetName() from ovs controller and we already have
Name() to return the name of the sdn plugin if needed.