### PR TITLE
Remove prompts from commented examples

### DIFF
--- a/pkg/cmd/admin/network/isolate_projects.go
+++ b/pkg/cmd/admin/network/isolate_projects.go
@@ -21,10 +21,10 @@ Isolate project network
 Allows projects to isolate their network from other projects when using the %[1]s network plugin.`
 
 	isolateProjectsNetworkExample = `	# Provide isolation for project p1
-	$ %[1]s <p1>
+	%[1]s <p1>
 
 	# Allow all projects with label name=top-secret to have their own isolated project network
-	$ %[1]s --selector='name=top-secret'`
+	%[1]s --selector='name=top-secret'`
 )
 
 type IsolateOptions struct {

--- a/pkg/cmd/admin/network/join_projects.go
+++ b/pkg/cmd/admin/network/join_projects.go
@@ -22,10 +22,10 @@ Join project network
 Allows projects to join existing project network when using the %[1]s network plugin.`
 
 	joinProjectsNetworkExample = `	# Allow project p2 to use project p1 network
-	$ %[1]s --to=<p1> <p2>
+	%[1]s --to=<p1> <p2>
 
 	# Allow all projects with label name=top-secret to use project p1 network
-	$ %[1]s --to=<p1> --selector='name=top-secret'`
+	%[1]s --to=<p1> --selector='name=top-secret'`
 )
 
 type JoinOptions struct {

--- a/pkg/cmd/admin/network/make_projects_global.go
+++ b/pkg/cmd/admin/network/make_projects_global.go
@@ -23,10 +23,10 @@ Make project network global
 Allows projects to access all pods in the cluster and vice versa when using the %[1]s network plugin.`
 
 	makeGlobalProjectsNetworkExample = `	# Allow project p1 to access all pods in the cluster and vice versa
-	$ %[1]s <p1>
+	%[1]s <p1>
 
 	# Allow all projects with label name=share to access all pods in the cluster and vice versa
-	$ %[1]s --selector='name=share'`
+	%[1]s --selector='name=share'`
 )
 
 type MakeGlobalOptions struct {


### PR DESCRIPTION
Following the upstream style changes from Kubernetes and OpenShift
Origin.

See https://github.com/openshift/origin/pull/8454.