### PR TITLE
Egress firewall support

### DIFF
--- a/pkg/ovs/ovs.go
+++ b/pkg/ovs/ovs.go
@@ -88,6 +88,14 @@ func (tx *Transaction) AddFlow(flow string, args ...interface{}) {
 	tx.ofctlExec("add-flow", tx.bridge, flow)
 }
 
+// ModFlows modifies all matching flows on the bridge. The arguments are passed to fmt.Sprintf().
+func (tx *Transaction) ModFlows(flow string, args ...interface{}) {
+	if len(args) > 0 {
+		flow = fmt.Sprintf(flow, args...)
+	}
+	tx.ofctlExec("mod-flows", tx.bridge, flow)
+}
+
 // DeleteFlows deletes all matching flows from the bridge. The arguments are
 // passed to fmt.Sprintf().
 func (tx *Transaction) DeleteFlows(flow string, args ...interface{}) {

--- a/plugins/osdn/registry.go
+++ b/plugins/osdn/registry.go
@@ -38,12 +38,13 @@ type Registry struct {
 type ResourceName string
 
 const (
-	Nodes         ResourceName = "Nodes"
-	Namespaces    ResourceName = "Namespaces"
-	NetNamespaces ResourceName = "NetNamespaces"
-	Services      ResourceName = "Services"
-	HostSubnets   ResourceName = "HostSubnets"
-	Pods          ResourceName = "Pods"
+	Nodes           ResourceName = "Nodes"
+	Namespaces      ResourceName = "Namespaces"
+	NetNamespaces   ResourceName = "NetNamespaces"
+	Services        ResourceName = "Services"
+	HostSubnets     ResourceName = "HostSubnets"
+	Pods            ResourceName = "Pods"
+	EgressFirewalls ResourceName = "EgressFirewalls"
 )
 
 func newRegistry(osClient *osclient.Client, kClient *kclient.Client) *Registry {
@@ -259,6 +260,10 @@ func (registry *Registry) getServices(namespace string) ([]kapi.Service, error) 
 	return servList, nil
 }
 
+func (registry *Registry) GetEgressFirewall() (*osapi.EgressFirewall, error) {
+	return registry.oClient.EgressFirewall().Get("default")
+}
+
 // Run event queue for the given resource
 func (registry *Registry) RunEventQueue(resourceName ResourceName) *oscache.EventQueue {
 	var client cache.Getter
@@ -283,6 +288,9 @@ func (registry *Registry) RunEventQueue(resourceName ResourceName) *oscache.Even
 	case Pods:
 		expectedType = &kapi.Pod{}
 		client = registry.kClient
+	case EgressFirewalls:
+		expectedType = &osapi.EgressFirewall{}
+		client = registry.oClient
 	default:
 		log.Fatalf("Unknown resource %s during initialization of event queue", resourceName)
 	}


### PR DESCRIPTION
This is missing the origin side, but that side doesn't quite work yet anyway. (Some problem with how I've defined the new resource type... it worked before when I had the firewall rules on the ClusterNetwork object instead of on a new type of object.) The interesting bit from origin is:

    +// EgressFirewallPolicy gives the type of an EgressFirewallRule
    +type EgressFirewallPolicy string
    +
    +const (
    +	EgressFirewallPolicyAllow EgressFirewallPolicy = "allow"
    +	EgressFirewallPolicyDeny  EgressFirewallPolicy = "deny"
    +)
    +
    +// EgressFirewallRule contains a single outgoing traffic firewall rule
    +type EgressFirewallRule struct {
    +	Policy EgressFirewallPolicy
    +	From   string // Namespace name or empty
    +	To     string // CIDR range
    +}
    +
    +// EgressFirewall provides a list of firewall rules on outgoing traffic
    +type EgressFirewall struct {
    +	unversioned.TypeMeta
    +	kapi.ObjectMeta
    +
    +	Rules []EgressFirewallRule
    +}

To avoid race conditions when updating the firewall rules, there are actually 3 tables in OVS for the firewall: table 9, which says "`output:2`" when there are no firewall rules, or "`goto_table:10`" or "`goto_table:11`" when there are, and then the actual rules are in either table 10 or 11, where only one of them is in use at any time, and when we need to update the rules, we update them into the *other* table, and then change table 9 to point to it only after everything is done.

After implementing that though, I realized that there are still other issues. Eg, if a namespace is firewalled, and you change its VNID, then there's a race condition, where some traffic coming out of a pod in that namespace could get assigned the new VNID while the firewall rules are still looking for the old VNID. Meh.

@openshift/networking PTAL. See https://trello.com/c/iH5IjWI8 for the use cases. As per earlier email, this is basically completely ignoring anything that might be going on upstream with respect to egress policy, due to timing/scope, but we do at least hopefully want this to be a subset of what eventually gets implemented upstream.