### PR TITLE
debug.sh will report incorrect message

### DIFF
--- a/hack/debug.sh
+++ b/hack/debug.sh
@@ -114,18 +114,10 @@ do_master () {
 	    continue
 	fi
 
-	if ! [[ $node =~ ^[0-9.]*$ ]]; then
-	    resolv_ip=$(awk '/\s'$node'$/ { print $1; exit; }' /etc/hosts)
-	    if [ -z "$resolv_ip" ]; then
-		resolv_ip=$(host $node 2>/dev/null | sed -ne 's/.*has address //p' | head -1)
-		if [ -z "$resolv_ip" ]; then
-		    echo "Node $node: no IP address in either DNS or /etc/hosts"
-		fi
-	    fi
+	resolv_ip=$(getent ahostsv4 $node | awk '/STREAM/ { print $1; exit; }')
 
-	    if [ "$reg_ip" != "$resolv_ip" ]; then
-		echo "Node $node: the IP in OpenShift ($reg_ip) does not match DNS/hosts ($resolv_ip)"
-	    fi
+	if [ "$reg_ip" != "$resolv_ip" ]; then
+	    echo "Node $node: the IP in OpenShift ($reg_ip) does not match DNS/hosts ($resolv_ip)"
 	fi
 
 	try_eval ping -c1 -W2 $node


### PR DESCRIPTION
When the /etc/hosts has extra spaces in the end of the line or the
node name is not the last token in the line the node is not discovered
and the result is error messages in the report.

This is fixed by using "getent ahostsv4" to look for the host name.
    
Fixes: 1328009

Signed-off-by: Phil Cameron <pcameron@redhat.com>