### PR TITLE
debug.sh: Use metadata.name instead of externalID to get node name

### DIFF
--- a/hack/debug.sh
+++ b/hack/debug.sh
@@ -81,7 +81,7 @@ log_system () {
 
 do_master () {
     kubelet_port=10250
-    if ! nodes=$(oc get nodes --template '{{range .items}}{{.spec.externalID}} {{end}}'); then
+    if ! nodes=$(oc get nodes --template '{{range .items}}{{.metadata.name}} {{end}}'); then
 	if [ -z "$KUBECONFIG" -o ! -f "$KUBECONFIG" ]; then
 	    die "KUBECONFIG is unset or incorrect"
 	else


### PR DESCRIPTION
When debug.sh gets Node name, it acquires `spec.externalID` from each
Node rather than `metadata.name`. Due to this, next command to get
IP fails, if `spec.externalID` and `metadata.name` are different.