### PR TITLE
debug.sh: continue to run script if controllers path exists

### DIFF
--- a/hack/debug.sh
+++ b/hack/debug.sh
@@ -541,7 +541,7 @@ case "$1" in
 	;;
 
     "")
-	if [ -z "$aos_master_service" ]; then
+	if [ -z "$aos_master_service" ] && [ -z "$aos_master_controllers_service" ]; then
 	    echo "Usage:"
 	    echo "  [from master]"
 	    echo "    $0"


### PR DESCRIPTION
Although atomic-openshift-master RPM package includes
`/usr/lib/systemd/system/atomic-openshift-master.service`, latest ansible
installer removes the file if installed with master HA configuration.

Please refer to
~~~
[root@knakayam-ose37-master1 ~]# rpm -qf /usr/lib/systemd/system/atomic-openshift-master.service
atomic-openshift-master-3.7.9-1.git.0.7c71a2d.el7.x86_64

[root@knakayam-ose37-master1 ~]# ls /usr/lib/systemd/system/atomic-openshift-master.service
ls: cannot access /usr/lib/systemd/system/atomic-openshift-master.service: No such file or directory
~~~

So, this patch changes script to continue to run if not only
`atomic-openshift-master.service` but also
`atomic-openshift-master-controllers.service` exists.