### PR TITLE
Fix function comments based on best practices from Effective Go

### DIFF
--- a/pkg/ipcmd/ipcmd.go
+++ b/pkg/ipcmd/ipcmd.go
@@ -119,7 +119,7 @@ func (tx *Transaction) AddSlave(slave string) {
 	tx.exec([]string{"link", "set", slave, "master", tx.link})
 }
 
-// AddSlave remotes the indicated slave interface from the bridge, bond, or team
+// DeleteSlave remotes the indicated slave interface from the bridge, bond, or team
 // interface associated with the transaction. (No error occurs if the interface
 // is not actually a slave of the transaction interface.)
 func (tx *Transaction) DeleteSlave(slave string) {

--- a/pkg/netutils/common.go
+++ b/pkg/netutils/common.go
@@ -25,7 +25,7 @@ func GenerateDefaultGateway(sna *net.IPNet) net.IP {
 	return net.IPv4(ip[0], ip[1], ip[2], ip[3]|0x1)
 }
 
-// Return Host IP Networks
+// GetHostIPNetworks returns Host IP Networks
 // Ignores provided interfaces and filters loopback and non IPv4 addrs.
 func GetHostIPNetworks(skipInterfaces []string) ([]*net.IPNet, error) {
 	hostInterfaces, err := net.Interfaces()


### PR DESCRIPTION
Hi, we updated some exported function comments based on best practices from [Effective Go](https://golang.org/doc/effective_go.html). It’s admittedly a relatively minor fix up. Does this help you?